### PR TITLE
Warn on variable redefinition only when the values are different.

### DIFF
--- a/src/WixToolset.Core/ExtensibilityServices/PreprocessHelper.cs
+++ b/src/WixToolset.Core/ExtensibilityServices/PreprocessHelper.cs
@@ -45,7 +45,7 @@ namespace WixToolset.Core.ExtensibilityServices
             }
             else
             {
-                if (showWarning)
+                if (showWarning && value != currentValue)
                 {
                     this.Messaging.Write(WarningMessages.VariableDeclarationCollision(context.CurrentSourceLineNumber, name, value, currentValue));
                 }

--- a/src/test/WixToolsetTest.CoreIntegration/PreprocessorFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/PreprocessorFixture.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using System.Linq;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using WixToolset.Data.Tuples;
+    using WixToolset.Data.WindowsInstaller;
+    using Xunit;
+
+    public class PreprocessorFixture
+    {
+        [Fact]
+        public void VariableRedefinitionIsAWarning()
+        {
+            var folder = TestData.Get(@"TestData\Variables");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Package.wxs"),
+                    Path.Combine(folder, "PackageComponents.wxs"),
+                    "-loc", Path.Combine(folder, "Package.en-us.wxl"),
+                    "-bindpath", Path.Combine(folder, "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(baseFolder, @"bin\test.msi")
+                }, out var messages);
+                Assert.Equal(0, result);
+
+                var warnings = messages.Where(message => message.Id == 1118);
+                Assert.Single(warnings);
+            }
+        }
+    }
+}
+

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/Package.en-us.wxl
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/Package.en-us.wxl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+
+</WixLocalization>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/Package.wxs
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<?define Foo = "Foo" ?>
+<?define Foo = "Foo" ?>
+
+<?define Bar = "Bar" ?>
+<?define Bar = "Baz" ?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Product Id="*" Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <Package InstallerVersion="200" Compressed="no" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+    <MediaTemplate />
+
+    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/PackageComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/PackageComponents.wxs
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+       <Component>
+         <File Source="test.txt" />
+       </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/data/test.txt
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Variables/data/test.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -49,6 +49,10 @@
     <Content Include="TestData\Assembly\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Assembly\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Assembly\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Variables\data\test.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Variables\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Variables\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Variables\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes wixtoolset/issues#5853