### PR TITLE
Clean and create export directory early.

### DIFF
--- a/src/WixToolset.Core.WindowsInstaller/Decompile/DecompileMsiOrMsmCommand.cs
+++ b/src/WixToolset.Core.WindowsInstaller/Decompile/DecompileMsiOrMsmCommand.cs
@@ -36,6 +36,12 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
             {
                 using (var database = new Database(this.Context.DecompilePath, OpenDatabase.ReadOnly))
                 {
+                    // Delete the directory and its files to prevent cab extraction failure due to an existing file.
+                    if (Directory.Exists(this.Context.ExtractFolder))
+                    {
+                        Directory.Delete(this.Context.ExtractFolder, true);
+                    }
+
                     var unbindCommand = new UnbindDatabaseCommand(this.Messaging, database, this.Context.DecompilePath, this.Context.DecompileType, this.Context.ExtractFolder, this.Context.IntermediateFolder, this.Context.IsAdminImage, false, skipSummaryInfo: false);
                     var output = unbindCommand.Execute();
                     var extractedFilePaths = new List<string>(unbindCommand.ExportedFiles);

--- a/src/WixToolset.Core.WindowsInstaller/Unbind/ExtractCabinetsCommand.cs
+++ b/src/WixToolset.Core.WindowsInstaller/Unbind/ExtractCabinetsCommand.cs
@@ -121,12 +121,6 @@ namespace WixToolset.Core.WindowsInstaller.Unbind
             // extract the cabinet files
             if (0 < cabinetFiles.Count)
             {
-                // delete the directory and its files to prevent cab extraction due to an existing file
-                if (Directory.Exists(this.ExportBasePath))
-                {
-                    Directory.Delete(this.ExportBasePath, true);
-                }
-
                 // ensure the directory exists or extraction will fail
                 Directory.CreateDirectory(this.ExportBasePath);
 


### PR DESCRIPTION
...to support extracting cabinets to the root of the export directory
rather than requiring files in cabinets to be extracted to their own
directory.