### PR TITLE
Load .wixlib intermediates with single creator

### DIFF
--- a/src/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -331,27 +331,20 @@ namespace WixToolset.Core.CommandLine
 
         private IEnumerable<Intermediate> LoadLibraries(IEnumerable<string> libraryFiles, ITupleDefinitionCreator creator)
         {
-            var libraries = new List<Intermediate>();
-
-            foreach (var libraryFile in libraryFiles)
+            try
             {
-                try
-                {
-                    var library = Intermediate.Load(libraryFile, creator);
-
-                    libraries.Add(library);
-                }
-                catch (WixCorruptFileException e)
-                {
-                    this.Messaging.Write(e.Error);
-                }
-                catch (WixUnexpectedFileFormatException e)
-                {
-                    this.Messaging.Write(e.Error);
-                }
+                return Intermediate.Load(libraryFiles, creator);
+            }
+            catch (WixCorruptFileException e)
+            {
+                this.Messaging.Write(e.Error);
+            }
+            catch (WixUnexpectedFileFormatException e)
+            {
+                this.Messaging.Write(e.Error);
             }
 
-            return libraries;
+            return Array.Empty<Intermediate>();
         }
 
         private IEnumerable<Localization> LoadLocalizationFiles(IEnumerable<string> locFiles, IDictionary<string, string> preprocessorVariables)
@@ -437,7 +430,7 @@ namespace WixToolset.Core.CommandLine
             public string OutputsFile { get; private set; }
 
             public string BuiltOutputsFile { get; private set; }
-            
+
             public CommandLine(IMessaging messaging)
             {
                 this.Messaging = messaging;

--- a/src/WixToolset.Core/ExtensibilityServices/TupleDefinitionCreator.cs
+++ b/src/WixToolset.Core/ExtensibilityServices/TupleDefinitionCreator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
 namespace WixToolset.Core.ExtensibilityServices
 {
@@ -23,7 +23,10 @@ namespace WixToolset.Core.ExtensibilityServices
 
         public void AddCustomTupleDefinition(IntermediateTupleDefinition definition)
         {
-            this.CustomDefinitionByName.Add(definition.Name, definition);
+            if (!this.CustomDefinitionByName.TryGetValue(definition.Name, out var existing) || definition.Revision > existing.Revision)
+            {
+                this.CustomDefinitionByName[definition.Name] = definition;
+            }
         }
 
         public bool TryGetTupleDefinitionByName(string name, out IntermediateTupleDefinition tupleDefinition)

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/OtherComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/OtherComponents.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ex="http://www.example.com/scheams/v1/wxs">
+  <Fragment>
+    <ComponentGroup Id="OtherComponents" Directory="INSTALLFOLDER">
+       <Component>
+         <File Source="other.txt" />
+         <ex:Example Id="Other" Value="Value" />
+       </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/Package.en-us.wxl
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/Package.en-us.wxl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+
+</WixLocalization>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/Package.wxs
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Product Id="*" Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <Package InstallerVersion="200" Compressed="no" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+    <MediaTemplate />
+
+    <Property Id="ExampleProperty" Value="$(ex.Test)" />
+
+    <PropertyRef Id="PropertyFromExampleWir" />
+
+    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="OtherComponents" />
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/PackageComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/PackageComponents.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ex="http://www.example.com/scheams/v1/wxs">
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+       <Component>
+         <File Source="example.txt" />
+         <ex:Example Id="Foo" Value="Bar" />
+       </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/data/example.txt
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/data/example.txt
@@ -1,0 +1,1 @@
+This is example.txt.

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/data/other.txt
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/data/other.txt
@@ -1,0 +1,1 @@
+This is other.txt.

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -38,6 +38,12 @@
     <Content Include="TestData\BadIf\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BadIf\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BadIf\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ComplexExampleExtension\data\example.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ComplexExampleExtension\data\other.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ComplexExampleExtension\OtherComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ComplexExampleExtension\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ComplexExampleExtension\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ComplexExampleExtension\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\SingleFile\data\test.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\SingleFile\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\SingleFile\Package.wxs" CopyToOutputDirectory="PreserveNewest" />

--- a/src/test/WixToolsetTest.CoreIntegration/WixlibFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/WixlibFixture.cs
@@ -1,0 +1,173 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using Example.Extension;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using WixToolset.Data.Tuples;
+    using Xunit;
+
+    public class WixlibFixture
+    {
+        [Fact]
+        public void CanBuildSingleFileUsingWixlib()
+        {
+            var folder = TestData.Get(@"TestData\SingleFile");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "PackageComponents.wxs"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(intermediateFolder, @"test.wixlib")
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Package.wxs"),
+                    "-loc", Path.Combine(folder, "Package.en-us.wxl"),
+                    "-lib", Path.Combine(intermediateFolder, @"test.wixlib"),
+                    "-bindpath", Path.Combine(folder, "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(baseFolder, @"bin\test.msi")
+                });
+
+                result.AssertSuccess();
+
+                var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"obj\test.wir"));
+                var section = intermediate.Sections.Single();
+
+                var wixFile = section.Tuples.OfType<WixFileTuple>().Single();
+                Assert.Equal(Path.Combine(folder, @"data\test.txt"), wixFile[WixFileTupleFields.Source].AsPath().Path);
+                Assert.Equal(@"test.txt", wixFile[WixFileTupleFields.Source].PreviousValue.AsPath().Path);
+            }
+        }
+
+        [Fact]
+        public void CanBuildWithExtensionUsingWixlib()
+        {
+            var folder = TestData.Get(@"TestData\ExampleExtension");
+            var extensionPath = Path.GetFullPath(new Uri(typeof(ExampleExtensionFactory).Assembly.CodeBase).LocalPath);
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "PackageComponents.wxs"),
+                    "-ext", extensionPath,
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(intermediateFolder, @"test.wixlib")
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Package.wxs"),
+                    "-loc", Path.Combine(folder, "Package.en-us.wxl"),
+                    "-lib", Path.Combine(intermediateFolder, @"test.wixlib"),
+                    "-ext", extensionPath,
+                    "-bindpath", Path.Combine(folder, "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(intermediateFolder, @"bin\test.msi")
+                });
+
+                result.AssertSuccess();
+
+                var intermediate = Intermediate.Load(Path.Combine(intermediateFolder, @"test.wir"));
+                var section = intermediate.Sections.Single();
+
+                var wixFile = section.Tuples.OfType<WixFileTuple>().Single();
+                Assert.Equal(Path.Combine(folder, @"data\example.txt"), wixFile[WixFileTupleFields.Source].AsPath().Path);
+                Assert.Equal(@"example.txt", wixFile[WixFileTupleFields.Source].PreviousValue.AsPath().Path);
+
+                var example = section.Tuples.Where(t => t.Definition.Type == TupleDefinitionType.MustBeFromAnExtension).Single();
+                Assert.Equal("Foo", example.Id.Id);
+                Assert.Equal("Foo", example[0].AsString());
+                Assert.Equal("Bar", example[1].AsString());
+            }
+        }
+
+        [Fact]
+        public void CanBuildWithExtensionUsingMultipleWixlibs()
+        {
+            var folder = TestData.Get(@"TestData\ComplexExampleExtension");
+            var extensionPath = Path.GetFullPath(new Uri(typeof(ExampleExtensionFactory).Assembly.CodeBase).LocalPath);
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "PackageComponents.wxs"),
+                    "-ext", extensionPath,
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(intermediateFolder, @"components.wixlib")
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "OtherComponents.wxs"),
+                    "-ext", extensionPath,
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(intermediateFolder, @"other.wixlib")
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Package.wxs"),
+                    "-loc", Path.Combine(folder, "Package.en-us.wxl"),
+                    "-lib", Path.Combine(intermediateFolder, @"components.wixlib"),
+                    "-lib", Path.Combine(intermediateFolder, @"other.wixlib"),
+                    "-ext", extensionPath,
+                    "-bindpath", Path.Combine(folder, "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(intermediateFolder, @"bin\test.msi")
+                });
+
+                result.AssertSuccess();
+
+                var intermediate = Intermediate.Load(Path.Combine(intermediateFolder, @"test.wir"));
+                var section = intermediate.Sections.Single();
+
+                var wixFiles = section.Tuples.OfType<WixFileTuple>().OrderBy(t => Path.GetFileName(t.Source.Path)).ToArray();
+                Assert.Equal(Path.Combine(folder, @"data\example.txt"), wixFiles[0][WixFileTupleFields.Source].AsPath().Path);
+                Assert.Equal(@"example.txt", wixFiles[0][WixFileTupleFields.Source].PreviousValue.AsPath().Path);
+                Assert.Equal(Path.Combine(folder, @"data\other.txt"), wixFiles[1][WixFileTupleFields.Source].AsPath().Path);
+                Assert.Equal(@"other.txt", wixFiles[1][WixFileTupleFields.Source].PreviousValue.AsPath().Path);
+
+                var examples = section.Tuples.Where(t => t.Definition.Type == TupleDefinitionType.MustBeFromAnExtension).ToArray();
+                Assert.Equal(new[] { "Foo", "Other" }, examples.Select(t => t.Id.Id).ToArray());
+                Assert.Equal(new[] { "Foo", "Other" }, examples.Select(t => t.AsString(0)).ToArray());
+                Assert.Equal(new[] { "Bar", "Value" }, examples.Select(t => t[1].AsString()).ToArray());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Using a single creator ensures definitions are shared and consistent
across the entire build.