### PR TITLE
Fix NullReferenceException in MsuPackage processing

### DIFF
--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -273,6 +273,7 @@ namespace WixToolset.Core.Burn
                     case WixBundlePackageType.Msu:
                         {
                             ProcessMsuPackageCommand command = new ProcessMsuPackageCommand();
+                            command.AuthoredPayloads = payloads;
                             command.Facade = facade;
                             command.Execute();
                         }


### PR DESCRIPTION
This PR fixes a NullReferenceException when creating a bundle containing an `MsuPackage`.

The first line in `ProcessMsuPackageCommand.Execute()` contains a call to `AuthoredPayloads.Get()`, but `AuthoredPayloads` was not set. For other package types, `AuthoredPayloads` is set just after the command object is constructed, so I did the same for `ProcessMsuPackageCommand`.

I have opened a PR in the wix4 repo as well: wixtoolset/wix4#263

This fix seems to work fine for the code in the wix4 repo, so I'm submitting a PR here as well, though I have not tested it, as I haven't yet gotten around to rolling a build of the new separated repos.