### PR TITLE
Include the preprocessed include files with the processed document

### DIFF
--- a/src/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -377,18 +377,18 @@ namespace WixToolset.Core.CommandLine
             context.SourcePath = sourcePath;
             context.Variables = preprocessorVariables;
 
-            XDocument document = null;
+            IPreprocessResult result = null;
             try
             {
                 var preprocessor = this.ServiceProvider.GetService<IPreprocessor>();
-                document = preprocessor.Preprocess(context);
+                result = preprocessor.Preprocess(context);
             }
             catch (WixException e)
             {
                 this.Messaging.Write(e.Error);
             }
 
-            return document;
+            return result?.Document;
         }
 
         private class CommandLine

--- a/src/WixToolset.Core/CommandLine/CompileCommand.cs
+++ b/src/WixToolset.Core/CommandLine/CompileCommand.cs
@@ -63,11 +63,11 @@ namespace WixToolset.Core.CommandLine
                 context.SourcePath = sourceFile.SourcePath;
                 context.Variables = this.PreprocessorVariables;
 
-                XDocument document = null;
+                IPreprocessResult result = null;
                 try
                 {
                     var preprocessor = this.ServiceProvider.GetService<IPreprocessor>();
-                    document = preprocessor.Preprocess(context);
+                    result = preprocessor.Preprocess(context);
                 }
                 catch (WixException e)
                 {
@@ -83,7 +83,7 @@ namespace WixToolset.Core.CommandLine
                 compileContext.Extensions = this.ExtensionManager.Create<ICompilerExtension>();
                 compileContext.OutputPath = sourceFile.OutputPath;
                 compileContext.Platform = this.Platform;
-                compileContext.Source = document;
+                compileContext.Source = result?.Document;
 
                 var compiler = this.ServiceProvider.GetService<ICompiler>();
                 var intermediate = compiler.Compile(compileContext);

--- a/src/WixToolset.Core/IncludedFile.cs
+++ b/src/WixToolset.Core/IncludedFile.cs
@@ -2,13 +2,13 @@
 
 namespace WixToolset.Core
 {
-    using System.Xml;
+    using WixToolset.Data;
     using WixToolset.Extensibility.Data;
 
-    public interface IPreprocessor
+    internal class IncludedFile : IIncludedFile
     {
-        IPreprocessResult Preprocess(IPreprocessContext context);
+        public string Path { get; set; }
 
-        IPreprocessResult Preprocess(IPreprocessContext context, XmlReader reader);
+        public SourceLineNumber SourceLineNumbers { get; set; }
     }
 }

--- a/src/WixToolset.Core/PreprocessResult.cs
+++ b/src/WixToolset.Core/PreprocessResult.cs
@@ -2,13 +2,14 @@
 
 namespace WixToolset.Core
 {
-    using System.Xml;
+    using System.Collections.Generic;
+    using System.Xml.Linq;
     using WixToolset.Extensibility.Data;
 
-    public interface IPreprocessor
+    public class PreprocessResult : IPreprocessResult
     {
-        IPreprocessResult Preprocess(IPreprocessContext context);
+        public XDocument Document { get; set; }
 
-        IPreprocessResult Preprocess(IPreprocessContext context, XmlReader reader);
+        public IEnumerable<IIncludedFile> IncludedFiles { get; set; }
     }
 }

--- a/src/WixToolset.Core/WixToolsetServiceProvider.cs
+++ b/src/WixToolset.Core/WixToolsetServiceProvider.cs
@@ -45,6 +45,8 @@ namespace WixToolset.Core
             this.AddService<IBindResult>((provider, singletons) => new BindResult());
             this.AddService<IComponentKeyPath>((provider, singletons) => new ComponentKeyPath());
             this.AddService<IDecompileResult>((provider, singletons) => new DecompileResult());
+            this.AddService<IIncludedFile>((provider, singletons) => new IncludedFile());
+            this.AddService<IPreprocessResult>((provider, singletons) => new PreprocessResult());
             this.AddService<IResolveFileResult>((provider, singletons) => new ResolveFileResult());
             this.AddService<IResolveResult>((provider, singletons) => new ResolveResult());
             this.AddService<IResolvedCabinet>((provider, singletons) => new ResolvedCabinet());


### PR DESCRIPTION
This change also cleans up the internal state handling of the preprocesor
to pass the processing state around rather than depend on "global state"
in member variables. This removes the need to "reset" the member
variables before preprocessing which is much cleaner.