### PR TITLE
Fix missing symbol for WixSuppressAction.

### DIFF
--- a/src/WixToolset.Core/Compiler.cs
+++ b/src/WixToolset.Core/Compiler.cs
@@ -13445,7 +13445,7 @@ namespace WixToolset.Core
                 {
                     if (suppress)
                     {
-                        var row = this.Core.CreateRow(childSourceLineNumbers, TupleDefinitionType.WixSuppressAction);
+                        var row = this.Core.CreateRow(childSourceLineNumbers, TupleDefinitionType.WixSuppressAction, new Identifier(AccessModifier.Public, sequenceTable, actionName));
                         row.Set(0, sequenceTable);
                         row.Set(1, actionName);
                     }

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/OverridableActions/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/OverridableActions/Package.wxs
@@ -7,6 +7,10 @@
         <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
         <MediaTemplate />
 
+        <InstallExecuteSequence>
+            <ValidateProductID Suppress="yes" />
+        </InstallExecuteSequence>
+
         <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
             <ComponentGroupRef Id="ProductComponents" />
             <ComponentGroupRef Id="Foo1" />


### PR DESCRIPTION
Exposes non-overridable standard actions so WixToolsetTest.CoreIntegration.LinkerFixture.CanBuildWithOverridableActions now fails.