### PR TITLE
Bug: Wixipl references to extension libraries

### DIFF
--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/Package.en-us.wxl
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/Package.en-us.wxl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+
+</WixLocalization>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/Package.wxs
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Product Id="*" Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <Package InstallerVersion="200" Compressed="no" InstallScope="perMachine" />
+
+        <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+        <MediaTemplate />
+
+        <CustomAction Id="CAFromExtension" BinaryKey="BinFromWir" DllEntry="DoesntExist" />
+
+        <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+            <ComponentGroupRef Id="ProductComponents" />
+        </Feature>
+    </Product>
+
+    <Fragment>
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="ProgramFilesFolder">
+                <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+            </Directory>
+        </Directory>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/PackageComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/PackageComponents.wxs
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+       <Component>
+         <File Source="test.txt" />
+       </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/data/test.txt
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/data/test.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -81,6 +81,10 @@
     <Content Include="TestData\OverridableActions\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\OverridableActions\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\OverridableActions\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Wixipl\data\test.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Wixipl\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Wixipl\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Wixipl\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/test/WixToolsetTest.CoreIntegration/WixiplFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/WixiplFixture.cs
@@ -2,12 +2,14 @@
 
 namespace WixToolsetTest.CoreIntegration
 {
+    using System;
     using System.IO;
     using System.Linq;
     using WixBuildTools.TestSupport;
     using WixToolset.Core.TestPackage;
     using WixToolset.Data;
     using WixToolset.Data.Tuples;
+    using Example.Extension;
     using Xunit;
 
     public class WixiplFixture
@@ -86,6 +88,105 @@ namespace WixToolsetTest.CoreIntegration
                     "-o", Path.Combine(baseFolder, @"bin\test.msi")
                 });
                 Assert.Equal((int)ErrorMessages.Ids.WixiplSourceFileIsExclusive, result.ExitCode);
+            }
+        }
+
+        [Fact]
+        public void CanBuildMsiUsingExtensionLibrary()
+        {
+            var folder = TestData.Get(@"TestData\Wixipl");
+            var extensionPath = Path.GetFullPath(new Uri(typeof(ExampleExtensionFactory).Assembly.CodeBase).LocalPath);
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    "-ext", extensionPath,
+                    Path.Combine(folder, "Package.wxs"),
+                    Path.Combine(folder, "PackageComponents.wxs"),
+                    "-loc", Path.Combine(folder, "Package.en-us.wxl"),
+                    "-bindpath", Path.Combine(folder, "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(baseFolder, @"bin\test.msi"),
+                });
+
+                result.AssertSuccess();
+
+                var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"obj\test.wir"));
+                var section = intermediate.Sections.Single();
+
+                {
+                    var wixFile = section.Tuples.OfType<WixFileTuple>().Single();
+                    Assert.Equal(Path.Combine(folder, @"data\test.txt"), wixFile[WixFileTupleFields.Source].AsPath().Path);
+                    Assert.Equal(@"test.txt", wixFile[WixFileTupleFields.Source].PreviousValue.AsPath().Path);
+                }
+
+                {
+                    var binary = section.Tuples.OfType<BinaryTuple>().Single();
+                    var path = binary[BinaryTupleFields.Data].AsPath().Path;
+                    Assert.Contains("Example.Extension", path);
+                    Assert.EndsWith(@"\0", path);
+                    Assert.Equal(@"BinFromWir", binary[BinaryTupleFields.Name].AsString());
+                }
+            }
+        }
+
+        [Fact]
+        public void CanBuildWixiplUsingExtensionLibrary()
+        {
+            var folder = TestData.Get(@"TestData\Wixipl");
+            var extensionPath = Path.GetFullPath(new Uri(typeof(ExampleExtensionFactory).Assembly.CodeBase).LocalPath);
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    "-ext", extensionPath,
+                    Path.Combine(folder, "Package.wxs"),
+                    Path.Combine(folder, "PackageComponents.wxs"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(intermediateFolder, @"test.wixipl"),
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(intermediateFolder, @"test.wixipl"),
+                    "-ext", extensionPath,
+                    "-loc", Path.Combine(folder, "Package.en-us.wxl"),
+                    "-bindpath", Path.Combine(folder, "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(baseFolder, @"bin\test.msi"),
+                });
+
+                result.AssertSuccess();
+
+                var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"obj\test.wir"));
+                var section = intermediate.Sections.Single();
+
+                {
+                    var wixFile = section.Tuples.OfType<WixFileTuple>().Single();
+                    Assert.Equal(Path.Combine(folder, @"data\test.txt"), wixFile[WixFileTupleFields.Source].AsPath().Path);
+                    Assert.Equal(@"test.txt", wixFile[WixFileTupleFields.Source].PreviousValue.AsPath().Path);
+                }
+
+                {
+                    var binary = section.Tuples.OfType<BinaryTuple>().Single();
+                    var path = binary[BinaryTupleFields.Data].AsPath().Path;
+                    Assert.Contains("Example.Extension", path);
+                    Assert.EndsWith(@"\0", path);
+                    Assert.Equal(@"BinFromWir", binary[BinaryTupleFields.Name].AsString());
+                }
             }
         }
     }


### PR DESCRIPTION
Add test demonstrating that a persisted .wixipl file has broken
references to bits in an extension's library. Same project built
via wix.exe in one pass works as expected.