### PR TITLE
Add failing test to demonstrate ProgId bug.

### DIFF
--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/Package.en-us.wxl
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/Package.en-us.wxl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+
+</WixLocalization>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/Package.wxs
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Product Id="*" Name="ProgId" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <Package InstallerVersion="200" Compressed="no" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+    <MediaTemplate />
+
+    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/PackageComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/PackageComponents.wxs
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Name="Foo.exe" Source="test.txt" />
+                <ProgId Id="Foo.File.hol.15" Advertise="yes" Description="Foo Holiday File">
+                    <ProgId Id="Foo.File.hol" />
+                    <Extension Id="hol">
+                        <Verb Id="Open" Argument="/hol &quot;%1&quot;" Sequence="1" />
+                    </Extension>
+                </ProgId>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/data/test.txt
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/data/test.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -85,6 +85,10 @@
     <Content Include="TestData\Wixipl\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Wixipl\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Wixipl\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ProgId\data\test.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ProgId\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ProgId\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ProgId\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When a parent ProgId has Advertise="yes" and a child ProgId omits Advertise, the compiler assumes it's a non-advertised ProgId. It should be advertised instead.