### PR TITLE
Undo CreateTuple change and add ErrorTuple test.

### DIFF
--- a/src/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
+++ b/src/WixToolset.Core/ExtensibilityServices/ParseHelper.cs
@@ -913,6 +913,18 @@ namespace WixToolset.Core.ExtensibilityServices
         {
             var tuple = tupleDefinition.CreateTuple(sourceLineNumbers, identifier);
 
+            if (null != identifier)
+            {
+                if (tuple.Definition.FieldDefinitions[0].Type == IntermediateFieldType.Number)
+                {
+                    tuple.Set(0, Convert.ToInt32(identifier.Id));
+                }
+                else
+                {
+                    tuple.Set(0, identifier.Id);
+                }
+            }
+
             section.Tuples.Add(tuple);
 
             return tuple;

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/Package.en-us.wxl
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/Package.en-us.wxl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+  <String Id="DowngradeError">A newer version of [ProductName] is already installed.</String>
+  <String Id="FeatureTitle">MsiPackage</String>
+</WixLocalization>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/Package.wxs
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Product Id="*" Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <Package InstallerVersion="200" Compressed="no" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+    <MediaTemplate />
+
+    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/PackageComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/PackageComponents.wxs
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <UI>
+            <Error Id="1234">
+                Category 55 Emergency Doomsday Crisis
+            </Error>
+        </UI>
+        <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+            <Component>
+                <File Source="test.txt" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/data/test.txt
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/data/test.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -28,6 +28,10 @@
     <Content Include="TestData\DialogsInInstallUISequence\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\DialogsInInstallUISequence\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\DialogsInInstallUISequence\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ErrorsInUI\data\test.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ErrorsInUI\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ErrorsInUI\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\ErrorsInUI\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\FeatureGroup\FeatureGroup.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Font\FontTitle.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Icon\SampleIcon.wxs" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
Strongly-typed tuples are preferred and avoid field-zero/id confusion.