### PR TITLE
Fix resolution of !(bind.ProductVersion.MsiId) bind variables

### DIFF
--- a/src/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
@@ -135,6 +135,11 @@ namespace WixToolset.Core.Burn.Bundles
                         this.Facade.PackageTuple.Description = ProcessMsiPackageCommand.GetProperty(db, "ARPCOMMENTS");
                     }
 
+                    if (String.IsNullOrEmpty(this.Facade.PackageTuple.Version))
+                    {
+                        this.Facade.PackageTuple.Version = msiPackage.ProductVersion;
+                    }
+
                     var payloadNames = this.GetPayloadTargetNames(packagePayload.Id.Id);
 
                     var msiPropertyNames = this.GetMsiPropertyNames(packagePayload.Id.Id);

--- a/src/WixToolset.Core/Bind/ResolveDelayedFieldsCommand.cs
+++ b/src/WixToolset.Core/Bind/ResolveDelayedFieldsCommand.cs
@@ -153,12 +153,11 @@ namespace WixToolset.Core.Bind
                     }
                     else
                     {
-                        string key = String.Format(CultureInfo.InvariantCulture, "{0}.{1}", variableId, variableScope).ToLower(CultureInfo.InvariantCulture);
-                        string resolvedValue = variableDefaultValue;
+                        var key = String.Format(CultureInfo.InvariantCulture, "{0}.{1}", variableId, variableScope).ToLower(CultureInfo.InvariantCulture);
 
-                        if (resolutionData.ContainsKey(key))
+                        if (!resolutionData.TryGetValue(key, out var resolvedValue))
                         {
-                            resolvedValue = resolutionData[key];
+                            resolvedValue = variableDefaultValue;
                         }
 
                         if ("bind" == variableNamespace)

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -44,6 +44,12 @@ namespace WixToolsetTest.CoreIntegration
                 var intermediate = Intermediate.Load(Path.Combine(intermediateFolder, @"test.wir"));
                 var section = intermediate.Sections.Single();
 
+                var bundleTuple = section.Tuples.OfType<WixBundleTuple>().Single();
+                Assert.Equal("1.0.0.0", bundleTuple.Version);
+
+                var previousVersion = bundleTuple.Fields[(int)WixBundleTupleFields.Version].PreviousValue;
+                Assert.Equal("!(bind.packageVersion.test.msi)", previousVersion.AsString());
+
                 var msiTuple = section.Tuples.OfType<WixBundlePackageTuple>().Single();
                 Assert.Equal("test.msi", msiTuple.Id.Id );
             }

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/Bundle.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/Bundle.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <Bundle Name="!(loc.BundleName)" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+  <Bundle Name="!(loc.BundleName)" Version="!(bind.packageVersion.test.msi)" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
       <BootstrapperApplication SourceFile="fakeba.dll" />
       <Chain>
           <MsiPackage SourceFile="test.msi">


### PR DESCRIPTION
Fixes wixtoolset/issues#4830