### PR TITLE
Use WixToolset.Burn package to get rid of -burnStubPath

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="wixtoolset-burn" value="https://ci.appveyor.com/nuget/wixtoolset-burn" />
     <add key="wixtoolset-core-native" value="https://ci.appveyor.com/nuget/wixtoolset-core-native" />
     <add key="wixtoolset-data" value="https://ci.appveyor.com/nuget/wixtoolset-data" />
     <add key="wixtoolset-dtf" value="https://ci.appveyor.com/nuget/wixtoolset-dtf" />

--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -31,7 +31,6 @@ namespace WixToolset.Core.Burn
 
             this.BackendHelper = context.ServiceProvider.GetService<IBackendHelper>();
 
-            this.BurnStubPath = context.BurnStubPath;
             this.DefaultCompressionLevel = context.DefaultCompressionLevel;
             this.DelayedFields = context.DelayedFields;
             this.ExpectedEmbeddedFiles = context.ExpectedEmbeddedFiles;
@@ -49,8 +48,6 @@ namespace WixToolset.Core.Burn
         private IMessaging Messaging { get; }
 
         private IBackendHelper BackendHelper { get; }
-
-        private string BurnStubPath { get; }
 
         private CompressionLevel? DefaultCompressionLevel { get; }
 
@@ -453,7 +450,7 @@ namespace WixToolset.Core.Burn
             }
 
             {
-                var command = new CreateBundleExeCommand(this.Messaging, this.BackendHelper, this.IntermediateFolder, this.OutputPath, bundleTuple, uxContainer, containers, this.BurnStubPath);
+                var command = new CreateBundleExeCommand(this.Messaging, this.BackendHelper, this.IntermediateFolder, this.OutputPath, bundleTuple, uxContainer, containers);
                 command.Execute();
 
                 fileTransfers.Add(command.Transfer);

--- a/src/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
@@ -14,7 +14,7 @@ namespace WixToolset.Core.Burn.Bundles
 
     internal class CreateBundleExeCommand
     {
-        public CreateBundleExeCommand(IMessaging messaging, IBackendHelper backendHelper, string intermediateFolder, string outputPath, WixBundleTuple bundleTuple, WixBundleContainerTuple uxContainer, IEnumerable<WixBundleContainerTuple> containers, string burnStubPath)
+        public CreateBundleExeCommand(IMessaging messaging, IBackendHelper backendHelper, string intermediateFolder, string outputPath, WixBundleTuple bundleTuple, WixBundleContainerTuple uxContainer, IEnumerable<WixBundleContainerTuple> containers)
         {
             this.Messaging = messaging;
             this.BackendHelper = backendHelper;
@@ -23,7 +23,6 @@ namespace WixToolset.Core.Burn.Bundles
             this.BundleTuple = bundleTuple;
             this.UXContainer = uxContainer;
             this.Containers = containers;
-            this.BurnStubPath = burnStubPath;
         }
 
         public IFileTransfer Transfer { get; private set; }
@@ -42,23 +41,14 @@ namespace WixToolset.Core.Burn.Bundles
 
         private IEnumerable<WixBundleContainerTuple> Containers { get; }
 
-        private string BurnStubPath { get; }
-
         public void Execute()
         {
             var bundleFilename = Path.GetFileName(this.OutputPath);
 
-            // Copy the burn.exe to a writable location then mark it to be moved to its final build location. Note
-            // that today, the x64 Burn uses the x86 stub.
+            // Copy the burn.exe to a writable location then mark it to be moved to its final build location.
 
-            var stubFile = this.BurnStubPath;
-
-            if (String.IsNullOrEmpty(stubFile))
-            {
-                var stubPlatform = (Platform.X64 == this.BundleTuple.Platform) ? "x86" : this.BundleTuple.Platform.ToString();
-
-                stubFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), stubPlatform, "burn.exe");
-            }
+            var stubPlatform = this.BundleTuple.Platform.ToString();
+            var stubFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), stubPlatform, "burn.exe");
 
             var bundleTempPath = Path.Combine(this.IntermediateFolder, bundleFilename);
 

--- a/src/WixToolset.Core.Burn/WixToolset.Core.Burn.csproj
+++ b/src/WixToolset.Core.Burn/WixToolset.Core.Burn.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="4.6.0" />
+    <PackageReference Include="WixToolset.Burn" Version="4.0.*" />
     <PackageReference Include="WixToolset.Core.Native" Version="4.0.*" />
     <PackageReference Include="WixToolset.Dtf.Resources" Version="4.0.*" NoWarn="NU1701" />
     <PackageReference Include="WixToolset.Dtf.WindowsInstaller" Version="4.0.*" NoWarn="NU1701" />

--- a/src/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -157,7 +157,7 @@ namespace WixToolset.Core.CommandLine
                         {
                             using (new IntermediateFieldContext("wix.bind"))
                             {
-                                this.BindPhase(wixipl, wxls, filterCultures, this.commandLine.CabCachePath, this.commandLine.BindPaths, this.commandLine.BurnStubPath);
+                                this.BindPhase(wixipl, wxls, filterCultures, this.commandLine.CabCachePath, this.commandLine.BindPaths);
                             }
                         }
                     }
@@ -294,7 +294,7 @@ namespace WixToolset.Core.CommandLine
             return linker.Link(context);
         }
 
-        private void BindPhase(Intermediate output, IEnumerable<Localization> localizations, IEnumerable<string> filterCultures, string cabCachePath, IEnumerable<IBindPath> bindPaths, string burnStubPath)
+        private void BindPhase(Intermediate output, IEnumerable<Localization> localizations, IEnumerable<string> filterCultures, string cabCachePath, IEnumerable<IBindPath> bindPaths)
         {
             var intermediateFolder = this.IntermediateFolder;
             if (String.IsNullOrEmpty(intermediateFolder))
@@ -328,7 +328,6 @@ namespace WixToolset.Core.CommandLine
                 {
                     var context = this.ServiceProvider.GetService<IBindContext>();
                     //context.CabbingThreadCount = this.CabbingThreadCount;
-                    context.BurnStubPath = burnStubPath;
                     context.CabCachePath = cabCachePath;
                     context.Codepage = resolveResult.Codepage;
                     //context.DefaultCompressionLevel = this.DefaultCompressionLevel;
@@ -491,8 +490,6 @@ namespace WixToolset.Core.CommandLine
 
             public List<IBindPath> BindPaths { get; } = new List<IBindPath>();
 
-            public string BurnStubPath { get; private set; }
-
             public string CabCachePath { get; private set; }
 
             public List<string> Cultures { get; } = new List<string>();
@@ -579,9 +576,6 @@ namespace WixToolset.Core.CommandLine
                             }
                             break;
                         }
-                        case "burnstub":
-                            this.BurnStubPath = parser.GetNextArgumentOrError(arg);
-                            return true;
 
                         case "cc":
                             this.CabCachePath = parser.GetNextArgumentOrError(arg);

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -19,7 +19,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void CanBuildMultiFileBundle()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var folder = TestData.Get(@"TestData\SimpleBundle");
 
             using (var fs = new DisposableFileSystem())
@@ -35,7 +34,6 @@ namespace WixToolsetTest.CoreIntegration
                     "-loc", Path.Combine(folder, "Bundle.en-us.wxl"),
                     "-bindpath", Path.Combine(folder, "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", Path.Combine(baseFolder, @"bin\test.exe")
                 });
 
@@ -49,7 +47,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void CanBuildSimpleBundle()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var folder = TestData.Get(@"TestData\SimpleBundle");
 
             using (var fs = new DisposableFileSystem())
@@ -68,7 +65,6 @@ namespace WixToolsetTest.CoreIntegration
                     "-loc", Path.Combine(folder, "Bundle.en-us.wxl"),
                     "-bindpath", Path.Combine(folder, "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", exePath,
                 });
 
@@ -113,7 +109,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void CanBuildSimpleBundleUsingExtensionBA()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var extensionPath = Path.GetFullPath(new Uri(typeof(ExampleExtensionFactory).Assembly.CodeBase).LocalPath);
             var folder = TestData.Get(@"TestData\SimpleBundle");
 
@@ -130,7 +125,6 @@ namespace WixToolsetTest.CoreIntegration
                     "-ext", extensionPath,
                     "-bindpath", Path.Combine(folder, "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", Path.Combine(baseFolder, @"bin\test.exe")
                 });
 
@@ -144,7 +138,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void CanBuildSingleExeBundle()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var folder = TestData.Get(@"TestData");
 
             using (var fs = new DisposableFileSystem())
@@ -161,7 +154,6 @@ namespace WixToolsetTest.CoreIntegration
                     "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
                     "-bindpath", Path.Combine(folder, ".Data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", exePath,
                 });
 
@@ -174,7 +166,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void CanBuildSingleExeRemotePayloadBundle()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var folder = TestData.Get(@"TestData");
 
             using (var fs = new DisposableFileSystem())
@@ -190,7 +181,6 @@ namespace WixToolsetTest.CoreIntegration
                     Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
                     "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", exePath,
                 });
 

--- a/src/test/WixToolsetTest.CoreIntegration/BundleManifestFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleManifestFixture.cs
@@ -15,7 +15,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void PopulatesManifestWithBundleExtension()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var folder = TestData.Get(@"TestData");
 
             using (var fs = new DisposableFileSystem())
@@ -35,7 +34,6 @@ namespace WixToolsetTest.CoreIntegration
                     Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
                     "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", bundlePath
                 });
 
@@ -63,7 +61,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void PopulatesManifestWithBundleExtensionSearches()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var extensionPath = Path.GetFullPath(new Uri(typeof(ExampleExtensionFactory).Assembly.CodeBase).LocalPath);
             var folder = TestData.Get(@"TestData");
 
@@ -85,7 +82,6 @@ namespace WixToolsetTest.CoreIntegration
                     "-ext", extensionPath,
                     "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", bundlePath
                 });
 
@@ -117,7 +113,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void PopulatesManifestWithSetVariables()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var folder = TestData.Get(@"TestData");
 
             using (var fs = new DisposableFileSystem())
@@ -136,7 +131,6 @@ namespace WixToolsetTest.CoreIntegration
                     Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
                     "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", bundlePath
                 });
 

--- a/src/test/WixToolsetTest.CoreIntegration/WixlibFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/WixlibFixture.cs
@@ -17,7 +17,6 @@ namespace WixToolsetTest.CoreIntegration
         [Fact]
         public void CanBuildSimpleBundleUsingWixlib()
         {
-            var burnStubPath = TestData.Get(@"TestData\.Data\burn.exe");
             var folder = TestData.Get(@"TestData\SimpleBundle");
 
             using (var fs = new DisposableFileSystem())
@@ -43,7 +42,6 @@ namespace WixToolsetTest.CoreIntegration
                     "-lib", Path.Combine(intermediateFolder, @"test.wixlib"),
                     "-bindpath", Path.Combine(folder, "data"),
                     "-intermediateFolder", intermediateFolder,
-                    "-burnStub", burnStubPath,
                     "-o", Path.Combine(baseFolder, @"bin\test.exe")
                 });
 


### PR DESCRIPTION
Stop using x86 stub for x64.