### PR TITLE
6164 - Move DisplayInternalUI into BalExtension

### DIFF
--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -94,7 +94,7 @@ namespace WixToolset.Core.Burn
             // this behavior.
             var bundleTuple = this.GetSingleTuple<WixBundleTuple>();
 
-            bundleTuple.BundleId = Guid.NewGuid().ToString("B").ToUpperInvariant();
+            bundleTuple.ProviderKey = bundleTuple.BundleId = Guid.NewGuid().ToString("B").ToUpperInvariant();
 
             bundleTuple.Attributes |= WixBundleAttributes.PerMachine; // default to per-machine but the first-per user package wil flip the bundle per-user.
 
@@ -376,7 +376,10 @@ namespace WixToolset.Core.Burn
                 var command = new ProcessDependencyProvidersCommand(this.Messaging, section, facades);
                 command.Execute();
 
-                bundleTuple.ProviderKey = command.BundleProviderKey; // set the overridable bundle provider key.
+                if (!String.IsNullOrEmpty(command.BundleProviderKey))
+                {
+                    bundleTuple.ProviderKey = command.BundleProviderKey; // set the overridable bundle provider key.
+                }
                 dependencyTuplesByKey = command.DependencyTuplesByKey;
             }
 

--- a/src/WixToolset.Core.Burn/Bundles/CreateBootstrapperApplicationManifestCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/CreateBootstrapperApplicationManifestCommand.cs
@@ -126,8 +126,6 @@ namespace WixToolset.Core.Burn.Bundles
 
                 if (package.SpecificPackageTuple is WixBundleMsiPackageTuple msiPackage)
                 {
-                    writer.WriteAttributeString("DisplayInternalUI", msiPackage.DisplayInternalUI ? "yes" : "no");
-
                     if (!String.IsNullOrEmpty(msiPackage.ProductCode))
                     {
                         writer.WriteAttributeString("ProductCode", msiPackage.ProductCode);
@@ -140,8 +138,6 @@ namespace WixToolset.Core.Burn.Bundles
                 }
                 else if (package.SpecificPackageTuple is WixBundleMspPackageTuple mspPackage)
                 {
-                    writer.WriteAttributeString("DisplayInternalUI", mspPackage.DisplayInternalUI ? "yes" : "no");
-
                     if (!String.IsNullOrEmpty(mspPackage.PatchCode))
                     {
                         writer.WriteAttributeString("ProductCode", mspPackage.PatchCode);

--- a/src/WixToolset.Core.Burn/Bundles/CreateBurnManifestCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/CreateBurnManifestCommand.cs
@@ -410,7 +410,6 @@ namespace WixToolset.Core.Burn.Bundles
                         writer.WriteAttributeString("ProductCode", msiPackage.ProductCode);
                         writer.WriteAttributeString("Language", msiPackage.ProductLanguage.ToString(CultureInfo.InvariantCulture));
                         writer.WriteAttributeString("Version", msiPackage.ProductVersion);
-                        writer.WriteAttributeString("DisplayInternalUI", msiPackage.DisplayInternalUI ? "yes" : "no");
                         if (!String.IsNullOrEmpty(msiPackage.UpgradeCode))
                         {
                             writer.WriteAttributeString("UpgradeCode", msiPackage.UpgradeCode);
@@ -420,7 +419,6 @@ namespace WixToolset.Core.Burn.Bundles
                     {
                         writer.WriteAttributeString("PatchCode", mspPackage.PatchCode);
                         writer.WriteAttributeString("PatchXml", mspPackage.PatchXml);
-                        writer.WriteAttributeString("DisplayInternalUI", mspPackage.DisplayInternalUI ? "yes" : "no");
 
                         // If there is still a chance that all of our patches will target a narrow set of
                         // product codes, add the patch list to the overall list.

--- a/src/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/WixToolset.Core/Compiler_Bundle.cs
@@ -230,13 +230,13 @@ namespace WixToolset.Core
 
             if (String.IsNullOrEmpty(name))
             {
-                logVariablePrefixAndExtension = String.Concat("WixBundleLog:Setup:.log");
+                logVariablePrefixAndExtension = String.Concat("WixBundleLog:Setup:log");
             }
             else
             {
                 // Ensure only allowable path characters are in "name" (and change spaces to underscores).
                 fileSystemSafeBundleName = CompilerCore.MakeValidLongFileName(name.Replace(' ', '_'), "_");
-                logVariablePrefixAndExtension = String.Concat("WixBundleLog:", fileSystemSafeBundleName, ":.log");
+                logVariablePrefixAndExtension = String.Concat("WixBundleLog:", fileSystemSafeBundleName, ":log");
             }
 
             this.activeName = String.IsNullOrEmpty(name) ? Common.GenerateGuid() : name;

--- a/src/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/WixToolset.Core/Compiler_Bundle.cs
@@ -1735,7 +1735,6 @@ namespace WixToolset.Core
             string msuKB = null;
             var enableSignatureVerification = YesNoType.No;
             var compressed = YesNoDefaultType.Default;
-            var displayInternalUI = YesNoType.NotSet;
             var enableFeatureSelection = YesNoType.NotSet;
             var forcePerMachine = YesNoType.NotSet;
             RemotePayload remotePayload = null;
@@ -1804,10 +1803,6 @@ namespace WixToolset.Core
                         break;
                     case "DisplayName":
                         displayName = this.Core.GetAttributeValue(sourceLineNumbers, attrib);
-                        break;
-                    case "DisplayInternalUI":
-                        displayInternalUI = this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib);
-                        allowed = (packageType == WixBundlePackageType.Msi || packageType == WixBundlePackageType.Msp);
                         break;
                     case "EnableFeatureSelection":
                         enableFeatureSelection = this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib);
@@ -2139,7 +2134,6 @@ namespace WixToolset.Core
 
                 case WixBundlePackageType.Msi:
                     WixBundleMsiPackageAttributes msiAttributes = 0;
-                    msiAttributes |= (YesNoType.Yes == displayInternalUI) ? WixBundleMsiPackageAttributes.DisplayInternalUI : 0;
                     msiAttributes |= (YesNoType.Yes == enableFeatureSelection) ? WixBundleMsiPackageAttributes.EnableFeatureSelection : 0;
                     msiAttributes |= (YesNoType.Yes == forcePerMachine) ? WixBundleMsiPackageAttributes.ForcePerMachine : 0;
 
@@ -2151,7 +2145,6 @@ namespace WixToolset.Core
 
                 case WixBundlePackageType.Msp:
                     WixBundleMspPackageAttributes mspAttributes = 0;
-                    mspAttributes |= (YesNoType.Yes == displayInternalUI) ? WixBundleMspPackageAttributes.DisplayInternalUI : 0;
                     mspAttributes |= (YesNoType.Yes == slipstream) ? WixBundleMspPackageAttributes.Slipstream : 0;
 
                     this.Core.AddTuple(new WixBundleMspPackageTuple(sourceLineNumbers, id)

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -6,6 +6,7 @@ namespace WixToolsetTest.CoreIntegration
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Xml;
     using Example.Extension;
     using WixBuildTools.TestSupport;
     using WixToolset.Core.TestPackage;
@@ -102,6 +103,16 @@ namespace WixToolsetTest.CoreIntegration
                     var bextManifestData = wixOutput.GetData(BurnConstants.BundleExtensionDataWixOutputStreamName);
                     var extractedBextManifestData = File.ReadAllText(Path.Combine(baFolderPath, "BundleExtensionData.xml"), Encoding.UTF8);
                     Assert.Equal(extractedBextManifestData, bextManifestData);
+
+                    var logElements = extractResult.SelectManifestNodes("/burn:BurnManifest/burn:Log");
+                    var logElement = (XmlNode)Assert.Single(logElements);
+                    Assert.Equal("<Log PathVariable='WixBundleLog' Prefix='~TestBundle' Extension='log' />", logElement.GetTestXml());
+
+                    var registrationElements = extractResult.SelectManifestNodes("/burn:BurnManifest/burn:Registration");
+                    var registrationElement = (XmlNode)Assert.Single(registrationElements);
+                    Assert.Equal($"<Registration Id='{bundleTuple.BundleId}' ExecutableName='test.exe' PerMachine='yes' Tag='' Version='1.0.0.0' ProviderKey='{bundleTuple.BundleId}'>" +
+                        "<Arp Register='yes' DisplayName='~TestBundle' DisplayVersion='1.0.0.0' Publisher='Example Corporation' />" +
+                        "</Registration>", registrationElement.GetTestXml());
                 }
             }
         }

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/BundleCustomTable/BundleCustomTable.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/BundleCustomTable/BundleCustomTable.wxs
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <PackageGroup Id="BundlePackages">
+            <PackageGroupRef Id="MinimalPackageGroup" />
+        </PackageGroup>
+
+        <CustomTable Id="BundleCustomTable" Unreal="yes">
+            <Column Id="Id" Type="string" PrimaryKey="yes" />
+            <Column Id="Column2" Type="string" PrimaryKey="yes" />
+
+            <Row>
+                <Data Column="Id">one</Data>
+                <Data Column="Column2">two</Data>
+            </Row>
+            <Row>
+                <Data Column="Column2">&lt;</Data>
+                <Data Column="Id">&gt;</Data>
+            </Row>
+            <Row>
+                <Data Column="Id">1</Data>
+                <Data Column="Column2">2</Data>
+            </Row>
+        </CustomTable>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -22,6 +22,7 @@
     <Content Include="TestData\AppSearch\NestedDirSearchUnderRegSearch.msi" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\AppSearch\RegistrySearch.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BadEnsureTable\BadEnsureTable.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\BundleCustomTable\BundleCustomTable.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BundleExtension\BundleExtension.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BundleExtension\BundleExtensionSearches.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BundleExtension\BundleWithSearches.wxs" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
Also other fixes needed to test the bundle:
* Process Unreal custom tables in CreateBootstrapperApplicationManifestCommand
* Fix Registration/@ProviderKey in Burn manifest

https://github.com/wixtoolset/issues/issues/6164