### PR TITLE
6209 - Use WixBootstrapperApplicationDllSymbol

### DIFF
--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -101,10 +101,10 @@ namespace WixToolset.Core.Burn
 
             bundleSymbol.Attributes |= WixBundleAttributes.PerMachine; // default to per-machine but the first-per user package wil flip the bundle per-user.
 
-            // Ensure there is one and only one row in the WixBootstrapperApplication table.
+            // Ensure there is one and only one row in the WixBootstrapperApplicationDll table.
             // The compiler and linker behavior should have colluded to get
             // this behavior.
-            var bundleApplicationSymbol = this.GetSingleSymbol<WixBootstrapperApplicationSymbol>();
+            var bundleApplicationDllSymbol = this.GetSingleSymbol<WixBootstrapperApplicationDllSymbol>();
 
             // Ensure there is one and only one row in the WixChain table.
             // The compiler and linker behavior should have colluded to get
@@ -440,7 +440,7 @@ namespace WixToolset.Core.Burn
             IEnumerable<WixBundlePayloadSymbol> uxPayloads;
             IEnumerable<WixBundleContainerSymbol> containers;
             {
-                var command = new CreateNonUXContainers(this.BackendHelper, section, bundleApplicationSymbol, payloadSymbols, this.IntermediateFolder, layoutDirectory, this.DefaultCompressionLevel);
+                var command = new CreateNonUXContainers(this.BackendHelper, section, bundleApplicationDllSymbol, payloadSymbols, this.IntermediateFolder, layoutDirectory, this.DefaultCompressionLevel);
                 command.Execute();
 
                 fileTransfers.AddRange(command.FileTransfers);
@@ -475,7 +475,7 @@ namespace WixToolset.Core.Burn
             }
 
             {
-                var command = new CreateBundleExeCommand(this.Messaging, this.BackendHelper, this.IntermediateFolder, this.OutputPath, bundleApplicationSymbol, bundleSymbol, uxContainer, containers);
+                var command = new CreateBundleExeCommand(this.Messaging, this.BackendHelper, this.IntermediateFolder, this.OutputPath, bundleApplicationDllSymbol, bundleSymbol, uxContainer, containers);
                 command.Execute();
 
                 fileTransfers.Add(command.Transfer);

--- a/src/WixToolset.Core.Burn/Bind/GenerateManifestDataFromIRCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/GenerateManifestDataFromIRCommand.cs
@@ -61,6 +61,7 @@ namespace WixToolset.Core.Burn.Bind
                     case SymbolDefinitionType.ProvidesDependency:
                     case SymbolDefinitionType.WixApprovedExeForElevation:
                     case SymbolDefinitionType.WixBootstrapperApplication:
+                    case SymbolDefinitionType.WixBootstrapperApplicationDll:
                     case SymbolDefinitionType.WixBundle:
                     case SymbolDefinitionType.WixBundleCatalog:
                     case SymbolDefinitionType.WixBundleContainer:

--- a/src/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/CreateBundleExeCommand.cs
@@ -17,13 +17,13 @@ namespace WixToolset.Core.Burn.Bundles
 
     internal class CreateBundleExeCommand
     {
-        public CreateBundleExeCommand(IMessaging messaging, IBackendHelper backendHelper, string intermediateFolder, string outputPath, WixBootstrapperApplicationSymbol bootstrapperApplicationSymbol, WixBundleSymbol bundleSymbol, WixBundleContainerSymbol uxContainer, IEnumerable<WixBundleContainerSymbol> containers)
+        public CreateBundleExeCommand(IMessaging messaging, IBackendHelper backendHelper, string intermediateFolder, string outputPath, WixBootstrapperApplicationDllSymbol bootstrapperApplicationDllSymbol, WixBundleSymbol bundleSymbol, WixBundleContainerSymbol uxContainer, IEnumerable<WixBundleContainerSymbol> containers)
         {
             this.Messaging = messaging;
             this.BackendHelper = backendHelper;
             this.IntermediateFolder = intermediateFolder;
             this.OutputPath = outputPath;
-            this.BootstrapperApplicationSymbol = bootstrapperApplicationSymbol;
+            this.BootstrapperApplicationDllSymbol = bootstrapperApplicationDllSymbol;
             this.BundleSymbol = bundleSymbol;
             this.UXContainer = uxContainer;
             this.Containers = containers;
@@ -39,7 +39,7 @@ namespace WixToolset.Core.Burn.Bundles
 
         private string OutputPath { get; }
 
-        private WixBootstrapperApplicationSymbol BootstrapperApplicationSymbol { get; }
+        private WixBootstrapperApplicationDllSymbol BootstrapperApplicationDllSymbol { get; }
 
         private WixBundleSymbol BundleSymbol { get; }
 
@@ -72,7 +72,7 @@ namespace WixToolset.Core.Burn.Bundles
 
             var windowsAssemblyVersion = GetWindowsAssemblyVersion(this.BundleSymbol);
 
-            var applicationManifestData = GenerateApplicationManifest(this.BundleSymbol, this.BootstrapperApplicationSymbol, this.OutputPath, windowsAssemblyVersion);
+            var applicationManifestData = GenerateApplicationManifest(this.BundleSymbol, this.BootstrapperApplicationDllSymbol, this.OutputPath, windowsAssemblyVersion);
 
             UpdateBurnResources(bundleTempPath, this.OutputPath, this.BundleSymbol, windowsAssemblyVersion, applicationManifestData);
 
@@ -101,7 +101,7 @@ namespace WixToolset.Core.Burn.Bundles
             }
         }
 
-        private static byte[] GenerateApplicationManifest(WixBundleSymbol bundleSymbol, WixBootstrapperApplicationSymbol bootstrapperApplicationSymbol, string outputPath, Version windowsAssemblyVersion)
+        private static byte[] GenerateApplicationManifest(WixBundleSymbol bundleSymbol, WixBootstrapperApplicationDllSymbol bootstrapperApplicationSymbol, string outputPath, Version windowsAssemblyVersion)
         {
             const string asmv1Namespace = "urn:schemas-microsoft-com:asm.v1";
             const string asmv3Namespace = "urn:schemas-microsoft-com:asm.v3";

--- a/src/WixToolset.Core.Burn/Bundles/CreateNonUXContainers.cs
+++ b/src/WixToolset.Core.Burn/Bundles/CreateNonUXContainers.cs
@@ -14,11 +14,11 @@ namespace WixToolset.Core.Burn.Bundles
 
     internal class CreateNonUXContainers
     {
-        public CreateNonUXContainers(IBackendHelper backendHelper, IntermediateSection section, WixBootstrapperApplicationSymbol bootstrapperApplicationSymbol, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols, string intermediateFolder, string layoutFolder, CompressionLevel? defaultCompressionLevel)
+        public CreateNonUXContainers(IBackendHelper backendHelper, IntermediateSection section, WixBootstrapperApplicationDllSymbol bootstrapperApplicationDllSymbol, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols, string intermediateFolder, string layoutFolder, CompressionLevel? defaultCompressionLevel)
         {
             this.BackendHelper = backendHelper;
             this.Section = section;
-            this.BootstrapperApplicationSymbol = bootstrapperApplicationSymbol;
+            this.BootstrapperApplicationDllSymbol = bootstrapperApplicationDllSymbol;
             this.PayloadSymbols = payloadSymbols;
             this.IntermediateFolder = intermediateFolder;
             this.LayoutFolder = layoutFolder;
@@ -39,7 +39,7 @@ namespace WixToolset.Core.Burn.Bundles
 
         private IntermediateSection Section { get; }
 
-        private WixBootstrapperApplicationSymbol BootstrapperApplicationSymbol { get; }
+        private WixBootstrapperApplicationDllSymbol BootstrapperApplicationDllSymbol { get; }
 
         private Dictionary<string, WixBundlePayloadSymbol> PayloadSymbols { get; }
 
@@ -81,9 +81,9 @@ namespace WixToolset.Core.Burn.Bundles
                     container.WorkingPath = Path.Combine(this.IntermediateFolder, container.Name);
                     container.AttachedContainerIndex = 0;
 
-                    // Gather the list of UX payloads but ensure the BootstrapperApplication Payload is the first
+                    // Gather the list of UX payloads but ensure the BootstrapperApplicationDll Payload is the first
                     // in the list since that is the Payload that Burn attempts to load.
-                    var baPayloadId = this.BootstrapperApplicationSymbol.Id.Id;
+                    var baPayloadId = this.BootstrapperApplicationDllSymbol.Id.Id;
 
                     foreach (var uxPayload in containerPayloads)
                     {

--- a/src/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/WixToolset.Core/Compiler_Bundle.cs
@@ -1122,7 +1122,7 @@ namespace WixToolset.Core
             var previousType = ComplexReferenceChildType.Unknown;
 
             // The BundleExtension element acts like a Payload element so delegate to the "Payload" attribute parsing code to parse and create a Payload entry.
-            if (this.ParsePayloadElementContent(node, ComplexReferenceParentType.Container, Compiler.BurnUXContainerId, previousType, previousId, false, out var id))
+            if (this.ParsePayloadElementContent(node, ComplexReferenceParentType.Container, Compiler.BurnUXContainerId, previousType, previousId, true, out var id))
             {
                 previousId = id;
                 previousType = ComplexReferenceChildType.Payload;
@@ -1151,19 +1151,6 @@ namespace WixToolset.Core
                 {
                     this.Core.ParseExtensionElement(node, child);
                 }
-            }
-
-            if (null == previousId)
-            {
-                // We need *either* <Payload> or <PayloadGroupRef> or even just @SourceFile on the BundleExtension...
-                // but we just say there's a missing <Payload>.
-                // TODO: Is there a better message for this?
-                this.Core.Write(ErrorMessages.ExpectedElement(sourceLineNumbers, node.Name.LocalName, "Payload"));
-            }
-
-            if (null == id)
-            {
-                this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "Id"));
             }
 
             // Add the BundleExtension.

--- a/src/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/WixToolset.Core/Compiler_Bundle.cs
@@ -1333,7 +1333,6 @@ namespace WixToolset.Core
             string name = null;
             string sourceFile = null;
             string downloadUrl = null;
-            RemotePayload remotePayload = null;
 
             // This list lets us evaluate extension attributes *after* all core attributes
             // have been parsed and dealt with, regardless of authoring order.
@@ -1402,41 +1401,11 @@ namespace WixToolset.Core
                 this.Core.ParseExtensionAttribute(node, extensionAttribute, context);
             }
 
-            // We only handle the elements we care about.  Let caller handle other children.
-            foreach (var child in node.Elements(CompilerCore.WixNamespace + "RemotePayload"))
-            {
-                var childSourceLineNumbers = Preprocessor.GetSourceLineNumbers(child);
+            // Let caller handle the children.
 
-                if (CompilerCore.WixNamespace == node.Name.Namespace && node.Name.LocalName != "ExePackage")
-                {
-                    this.Core.Write(ErrorMessages.RemotePayloadUnsupported(childSourceLineNumbers));
-                    continue;
-                }
-
-                if (null != remotePayload)
-                {
-                    this.Core.Write(ErrorMessages.TooManyChildren(childSourceLineNumbers, node.Name.LocalName, child.Name.LocalName));
-                }
-
-                remotePayload = this.ParseRemotePayloadElement(child);
-            }
-
-            if (null != sourceFile && null != remotePayload)
-            {
-                this.Core.Write(ErrorMessages.UnexpectedElementWithAttribute(sourceLineNumbers, node.Name.LocalName, "RemotePayload", "SourceFile"));
-            }
-            else if (null == sourceFile && null == remotePayload)
-            {
-                this.Core.Write(ErrorMessages.ExpectedAttributeOrElement(sourceLineNumbers, node.Name.LocalName, "SourceFile", "RemotePayload"));
-            }
-            else if (null == sourceFile)
+            if (null == sourceFile)
             {
                 sourceFile = String.Empty;
-            }
-
-            if (null == downloadUrl && null != remotePayload)
-            {
-                this.Core.Write(ErrorMessages.ExpectedAttributeWithElement(sourceLineNumbers, node.Name.LocalName, "DownloadUrl", "RemotePayload"));
             }
 
             if (Compiler.BurnUXContainerId == parentId)
@@ -1449,7 +1418,7 @@ namespace WixToolset.Core
                 compressed = YesNoDefaultType.Yes;
             }
 
-            this.CreatePayloadRow(sourceLineNumbers, id, name, sourceFile, downloadUrl, parentType, parentId, previousType, previousId, compressed, enableSignatureVerification, null, null, remotePayload);
+            this.CreatePayloadRow(sourceLineNumbers, id, name, sourceFile, downloadUrl, parentType, parentId, previousType, previousId, compressed, enableSignatureVerification, null, null, null);
 
             return id;
         }

--- a/src/test/Example.Extension/Data/example.wxs
+++ b/src/test/Example.Extension/Data/example.wxs
@@ -1,4 +1,3 @@
-<?xml version='1.0'?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Fragment>
     <Property Id="PropertyFromExampleWir" Value="FromWir" />
@@ -6,7 +5,9 @@
     <Binary Id="BinFromWir" SourceFile="example.txt" />
   </Fragment>
   <Fragment>
-    <BootstrapperApplication Id="fakeba" SourceFile="example.txt" />
+    <BootstrapperApplication Id="fakeba">
+      <BootstrapperApplicationDll SourceFile="example.txt" />
+    </BootstrapperApplication>
   </Fragment>
   <Fragment>
     <BundleExtension Id="ExampleBundleExtension" SourceFile="example.txt" />

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/BundleWithPackageGroupRef/Bundle.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/BundleWithPackageGroupRef/Bundle.wxs
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Bundle Name="BurnBundle" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="B94478B1-E1F3-4700-9CE8-6AA090854AEC">
-        <BootstrapperApplication SourceFile="fakeba.dll" />
+        <BootstrapperApplication>
+            <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+        </BootstrapperApplication>
         <Chain>
             <PackageGroupRef Id="BundlePackages" />
         </Chain>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/Bundle.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/Bundle.wxs
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Bundle Name="!(loc.BundleName)" Version="!(bind.packageVersion.test.msi)" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
-      <BootstrapperApplication SourceFile="fakeba.dll" />
-      <Chain>
-          <MsiPackage SourceFile="test.msi">
-              <MsiProperty Name="TEST" Value="1" />
-          </MsiPackage>
-      </Chain>
+    <BootstrapperApplication>
+      <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+    </BootstrapperApplication>
+    <Chain>
+      <MsiPackage SourceFile="test.msi">
+        <MsiProperty Name="TEST" Value="1" />
+      </MsiPackage>
+    </Chain>
   </Bundle>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/MultiFileBootstrapperApplication.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/MultiFileBootstrapperApplication.wxs
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Fragment>
-    <BootstrapperApplication Id="fakeba" SourceFile="fakeba.dll" />
+    <BootstrapperApplication Id="fakeba">
+      <BootstrapperApplicationDll SourceFile="fakeba.dll" />
+    </BootstrapperApplication>
   </Fragment>
 </Wix>


### PR DESCRIPTION
Core toolset half of https://github.com/wixtoolset/issues/issues/6209