### PR TITLE
Add failing tests

### DIFF
--- a/src/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -578,7 +578,7 @@ namespace WixToolset.Core.CommandLine
                         case "bindpath":
                         {
                             var value = parser.GetNextArgumentOrError(arg);
-                            if (this.TryParseBindPath(value, out var bindPath))
+                            if (value != null && this.TryParseBindPath(value, out var bindPath))
                             {
                                 this.BindPaths.Add(bindPath);
                                 return true;

--- a/src/WixToolset.Core/CommandLine/CommandLineParser.cs
+++ b/src/WixToolset.Core/CommandLine/CommandLineParser.cs
@@ -138,9 +138,10 @@ namespace WixToolset.Core.CommandLine
         {
             var result = this.TryGetNextSwitchOrArgument(out arg);
 
-            if (!result && !this.IsSwitch(arg))
+            if (!result || this.IsSwitch(arg))
             {
                 this.ErrorArgument = arg ?? CommandLineParser.ExpectedArgument;
+                return false;
             }
 
             return result;

--- a/src/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/WixToolset.Core/Compiler_Bundle.cs
@@ -1404,7 +1404,7 @@ namespace WixToolset.Core
                         enableSignatureVerification = this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib);
                         break;
                     case "DpiAwareness":
-                        if (node.Name.LocalName != "BootstrapperApplication")
+                        if (node.Name.LocalName != "BootstrapperApplicationDll")
                         {
                             this.Core.UnexpectedAttribute(node, attrib);
                         }

--- a/src/test/WixToolsetTest.CoreIntegration/BootstrapperApplicationFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BootstrapperApplicationFixture.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using System.Linq;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using WixToolset.Data.Symbols;
+    using Xunit;
+
+    public class BootstrapperApplicationFixture
+    {
+        [Fact]
+        public void CanSetBootstrapperApplicationDllDpiAwareness()
+        {
+            var folder = TestData.Get(@"TestData\BootstrapperApplication");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var wixlibPath = Path.Combine(intermediateFolder, @"test.wixlib");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "DpiAwareness.wxs"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", wixlibPath,
+                });
+
+                result.AssertSuccess();
+
+                var intermediate = Intermediate.Load(wixlibPath);
+                var allSymbols = intermediate.Sections.SelectMany(s => s.Symbols);
+                var baDllSymbol = allSymbols.OfType<WixBootstrapperApplicationDllSymbol>()
+                                              .SingleOrDefault();
+                Assert.NotNull(baDllSymbol);
+
+                Assert.Equal(WixBootstrapperApplicationDpiAwarenessType.GdiScaled, baDllSymbol.DpiAwareness);
+            }
+        }
+    }
+}

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -216,7 +216,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "Test demonstrates failure")] //https://github.com/wixtoolset/issues/issues/4628
+        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4628")]
         public void CantBuildWithDuplicateCacheIds()
         {
             var folder = TestData.Get(@"TestData");
@@ -242,7 +242,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "Test demonstrates failure")] //https://github.com/wixtoolset/issues/issues/4574
+        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4574")]
         public void CantBuildWithDuplicatePayloadNames()
         {
             var folder = TestData.Get(@"TestData");
@@ -268,7 +268,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "Test demonstrates failure")] //https://github.com/wixtoolset/issues/issues/6291
+        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/6291")]
         public void CantBuildWithUnscheduledPackage()
         {
             var folder = TestData.Get(@"TestData");
@@ -294,7 +294,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "Test demonstrates failure")] //https://github.com/wixtoolset/issues/issues/6291
+        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/6291")]
         public void CantBuildWithUnscheduledRollbackBoundary()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -189,35 +189,6 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "Test demonstrates failure")]
-        public void CantBuildSingleExeBundleWithInvalidArgument()
-        {
-            var folder = TestData.Get(@"TestData");
-
-            using (var fs = new DisposableFileSystem())
-            {
-                var baseFolder = fs.GetFolder();
-                var intermediateFolder = Path.Combine(baseFolder, "obj");
-                var exePath = Path.Combine(baseFolder, @"bin\test.exe");
-
-                var result = WixRunner.Execute(new[]
-                {
-                    "build",
-                    Path.Combine(folder, "SingleExeBundle", "SingleExePackageGroup.wxs"),
-                    Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
-                    "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
-                    "-bindpath", Path.Combine(folder, ".Data"),
-                    "-intermediateFolder", intermediateFolder,
-                    "-o", exePath,
-                    "-nonexistentswitch", "param",
-                });
-
-                Assert.NotEqual(0, result.ExitCode);
-
-                Assert.False(File.Exists(exePath));
-            }
-        }
-
         [Fact]
         public void CanBuildSingleExeRemotePayloadBundle()
         {

--- a/src/test/WixToolsetTest.CoreIntegration/ContainerFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/ContainerFixture.cs
@@ -1,0 +1,140 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using WixToolset.Data.Symbols;
+    using Xunit;
+
+    public class ContainerFixture
+    {
+        [Fact]
+        public void HarvestedPayloadsArePutInCorrectContainer()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var binFolder = Path.Combine(baseFolder, "bin");
+                var bundlePath = Path.Combine(binFolder, "test.exe");
+                var baFolderPath = Path.Combine(baseFolder, "ba");
+                var extractFolderPath = Path.Combine(baseFolder, "extract");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "MsiTransaction", "FirstX86.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "MinimalComponentGroup.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(binFolder, "FirstX86.msi"),
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "MsiTransaction", "FirstX64.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "MinimalComponentGroup.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(binFolder, "FirstX64.msi"),
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Container", "HarvestIntoDetachedContainer.wxs"),
+                    Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
+                    "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
+                    "-bindpath", binFolder,
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", bundlePath
+                });
+
+                result.AssertSuccess();
+
+                Assert.True(File.Exists(bundlePath));
+
+                var extractResult = BundleExtractor.ExtractBAContainer(null, bundlePath, baFolderPath, extractFolderPath);
+                extractResult.AssertSuccess();
+
+                var payloads = extractResult.SelectManifestNodes("/burn:BurnManifest/burn:Payload");
+                Assert.Equal(4, payloads.Count);
+                var ignoreAttributes = new Dictionary<string, List<string>> { { "Payload", new List<string> { "FileSize", "Hash" } } };
+                Assert.Equal(@"<Payload Id='FirstX86.msi' FilePath='FirstX86.msi' FileSize='*' Hash='*' Packaging='embedded' SourcePath='a0' Container='WixAttachedContainer' />", payloads[0].GetTestXml(ignoreAttributes));
+                Assert.Equal(@"<Payload Id='FirstX64.msi' FilePath='FirstX64.msi' FileSize='*' Hash='*' Packaging='embedded' SourcePath='a1' Container='FirstX64' />", payloads[1].GetTestXml(ignoreAttributes));
+                Assert.Equal(@"<Payload Id='fk1m38Cf9RZ2Bx_ipinRY6BftelU' FilePath='PFiles\MsiPackage\test.txt' FileSize='*' Hash='*' Packaging='embedded' SourcePath='a2' Container='WixAttachedContainer' />", payloads[2].GetTestXml(ignoreAttributes));
+                Assert.Equal(@"<Payload Id='fC0n41rZK8oW3JK8LzHu6AT3CjdQ' FilePath='PFiles\MsiPackage\test.txt' FileSize='*' Hash='*' Packaging='embedded' SourcePath='a3' Container='FirstX64' />", payloads[3].GetTestXml(ignoreAttributes));
+            }
+        }
+
+        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/6144")]
+        public void MultipleAttachedContainersAreNotCurrentlySupported()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var binFolder = Path.Combine(baseFolder, "bin");
+                var bundlePath = Path.Combine(binFolder, "test.exe");
+                var baFolderPath = Path.Combine(baseFolder, "ba");
+                var extractFolderPath = Path.Combine(baseFolder, "extract");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "MsiTransaction", "FirstX86.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "MinimalComponentGroup.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(binFolder, "FirstX86.msi"),
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "MsiTransaction", "FirstX64.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "MinimalComponentGroup.wxs"),
+                    Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", Path.Combine(binFolder, "FirstX64.msi"),
+                });
+
+                result.AssertSuccess();
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Container", "MultipleAttachedContainers.wxs"),
+                    Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
+                    "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
+                    "-bindpath", binFolder,
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", bundlePath
+                });
+
+                Assert.InRange(result.ExitCode, 2, Int32.MaxValue);
+            }
+        }
+    }
+}

--- a/src/test/WixToolsetTest.CoreIntegration/CustomActionFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/CustomActionFixture.cs
@@ -11,7 +11,7 @@ namespace WixToolsetTest.CoreIntegration
 
     public class CustomActionFixture
     {
-        [Fact(Skip = "Test demonstrates failure")] //https://github.com/wixtoolset/issues/issues/6201
+        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/6201")]
         public void CanDetectCustomActionCycle()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
@@ -55,6 +55,7 @@ namespace WixToolsetTest.CoreIntegration
                 var result = WixRunner.Execute(new[]
                 {
                     "build",
+                    "-sw1008", // this is expected for this test
                     Path.Combine(folder, "Package.wxs"),
                     Path.Combine(folder, "PackageComponents.wxs"),
                     "-loc", Path.Combine(folder, "Package.en-us.wxl"),

--- a/src/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
@@ -162,6 +162,7 @@ namespace WixToolsetTest.CoreIntegration
                 var result = WixRunner.Execute(new[]
                 {
                     "build",
+                    "-sw1079", // TODO: why does this test need to create a second cab which is empty?
                     Path.Combine(folder, "Package.wxs"),
                     Path.Combine(folder, "PackageComponents.wxs"),
                     "-loc", Path.Combine(folder, "Package.en-us.wxl"),

--- a/src/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
@@ -357,6 +357,7 @@ namespace WixToolsetTest.CoreIntegration
                 var result = WixRunner.Execute(new[]
                 {
                     "build",
+                    "-sw1031", // this is expected for this test
                     Path.Combine(folder, "DefaultDir", "DefaultDir.wxs"),
                     Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
                     "-bindpath", Path.Combine(folder, "SingleFile", "data"),

--- a/src/test/WixToolsetTest.CoreIntegration/MsiTransactionFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/MsiTransactionFixture.cs
@@ -26,6 +26,7 @@ namespace WixToolsetTest.CoreIntegration
                 var result = WixRunner.Execute(new[]
                 {
                     "build",
+                    "-sw1151", // this is expected for this test
                     Path.Combine(folder, "MsiTransaction", "X64AfterX86Bundle.wxs"),
                     Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
                     "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
@@ -55,6 +56,7 @@ namespace WixToolsetTest.CoreIntegration
                 var result = WixRunner.Execute(new[]
                 {
                     "build",
+                    "-sw1151", // this is expected for this test
                     Path.Combine(folder, "MsiTransaction", "X86AfterX64Bundle.wxs"),
                     Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
                     "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),

--- a/src/test/WixToolsetTest.CoreIntegration/PayloadFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/PayloadFixture.cs
@@ -61,7 +61,7 @@ namespace WixToolsetTest.CoreIntegration
                 var intermediateFolder = Path.Combine(baseFolder, "obj");
                 var wixlibPath = Path.Combine(intermediateFolder, @"test.wixlib");
 
-                var result = WixRunner.Execute(new[]
+                var result = WixRunner.Execute(warningsAsErrors: false, new[]
                 {
                     "build",
                     Path.Combine(folder, "CanonicalizeName.wxs"),

--- a/src/test/WixToolsetTest.CoreIntegration/PreprocessorFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/PreprocessorFixture.cs
@@ -49,7 +49,7 @@ namespace WixToolsetTest.CoreIntegration
                 var baseFolder = fs.GetFolder();
                 var intermediateFolder = Path.Combine(baseFolder, "obj");
 
-                var result = WixRunner.Execute(new[]
+                var result = WixRunner.Execute(warningsAsErrors: false, new[]
                 {
                     "build",
                     Path.Combine(folder, "Package.wxs"),

--- a/src/test/WixToolsetTest.CoreIntegration/RegistryFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/RegistryFixture.cs
@@ -111,7 +111,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "Test demonstrates failure")] //https://github.com/wixtoolset/issues/issues/4753
+        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4753")]
         public void PopulatesRegistryTableWithoutExtraBackslash()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/test/WixToolsetTest.CoreIntegration/RollbackBoundaryFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/RollbackBoundaryFixture.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using Xunit;
+
+    public class RollbackBoundaryFixture
+    {
+        [Fact(Skip = "Test demonstrates failure")]
+        public void CanStartChainWithRollbackBoundary()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var exePath = Path.Combine(baseFolder, @"bin\test.exe");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "RollbackBoundary", "BeginningOfChain.wxs"),
+                    Path.Combine(folder, "BundleWithPackageGroupRef", "Bundle.wxs"),
+                    Path.Combine(folder, "BundleWithPackageGroupRef", "MinimalPackageGroup.wxs"),
+                    "-bindpath", Path.Combine(folder, "SimpleBundle", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", exePath,
+                });
+
+                result.AssertSuccess();
+
+                Assert.True(File.Exists(exePath));
+            }
+        }
+
+    }
+}

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/BootstrapperApplication/DpiAwareness.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/BootstrapperApplication/DpiAwareness.wxs
@@ -1,0 +1,7 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <BootstrapperApplication Id="fakeba">
+      <BootstrapperApplicationDll SourceFile="$(sys.SOURCEFILEPATH)" DpiAwareness="gdiScaled" />
+    </BootstrapperApplication>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Container/HarvestIntoDetachedContainer.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Container/HarvestIntoDetachedContainer.wxs
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <PackageGroup Id="BundlePackages">
+            <MsiPackage SourceFile="FirstX86.msi" />
+            <PackageGroupRef Id="FirstX64" />
+        </PackageGroup>
+        <PackageGroup Id="FirstX64">
+            <MsiPackage SourceFile="FirstX64.msi" />
+        </PackageGroup>
+        <Container Id="FirstX64" Name="FirstX64" Type="detached">
+            <PackageGroupRef Id="FirstX64" />
+        </Container>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Container/MultipleAttachedContainers.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Container/MultipleAttachedContainers.wxs
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <PackageGroup Id="BundlePackages">
+            <MsiPackage SourceFile="FirstX86.msi" />
+            <PackageGroupRef Id="FirstX64" />
+        </PackageGroup>
+        <PackageGroup Id="FirstX64">
+            <MsiPackage SourceFile="FirstX64.msi" />
+        </PackageGroup>
+        <Container Id="FirstX64" Name="FirstX64" Type="attached">
+            <PackageGroupRef Id="FirstX64" />
+        </Container>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Payload/SharedBAAndPackagePayloadBundle.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Payload/SharedBAAndPackagePayloadBundle.wxs
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <PackageGroup Id="BundlePackages">
+            <ExePackage SourceFile="burn.exe">
+                <PayloadGroupRef Id="Shared" />
+            </ExePackage>
+        </PackageGroup>
+        <BootstrapperApplication>
+            <PayloadGroupRef Id="Shared" />
+        </BootstrapperApplication>
+        <PayloadGroup Id="Shared">
+            <Payload SourceFile="$(sys.SOURCEFILEPATH)" />
+        </PayloadGroup>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/RollbackBoundary/BeginningOfChain.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/RollbackBoundary/BeginningOfChain.wxs
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <PackageGroup Id="BundlePackages">
+            <RollbackBoundary Id="nonvital" Vital="no" />
+            <PackageGroupRef Id="MinimalPackageGroup" />
+        </PackageGroup>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/WarningFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/WarningFixture.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using WixBuildTools.TestSupport;
+    using WixToolset.Core.TestPackage;
+    using WixToolset.Data;
+    using Xunit;
+
+    public class WarningFixture
+    {
+        [Fact]
+        public void SuppressedWarningsWithWarningAsErrorsAreNotErrors()
+        {
+            var folder = TestData.Get(@"TestData\Payload");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var wixlibPath = Path.Combine(intermediateFolder, @"test.wixlib");
+
+                var result = WixRunner.Execute(warningsAsErrors: true, new[]
+                {
+                    "build",
+                    "-sw1152",
+                    Path.Combine(folder, "CanonicalizeName.wxs"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", wixlibPath,
+                });
+
+                result.AssertSuccess();
+            }
+        }
+
+        [Fact]
+        public void WarningsAsErrorsTreatsWarningsAsErrors()
+        {
+            var folder = TestData.Get(@"TestData\Payload");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var wixlibPath = Path.Combine(intermediateFolder, @"test.wixlib");
+
+                var result = WixRunner.Execute(warningsAsErrors: true, new[]
+                {
+                    "build",
+                    Path.Combine(folder, "CanonicalizeName.wxs"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", wixlibPath,
+                });
+
+                Assert.Equal((int)WarningMessages.Ids.PathCanonicalized, result.ExitCode);
+
+                var message = Assert.Single(result.Messages);
+                Assert.Equal(MessageLevel.Warning, message.Level); // TODO: is this right?
+            }
+        }
+    }
+}

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -38,6 +38,8 @@
     <Content Include="TestData\Class\DecompiledOldClassTableDef.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Class\IconIndex0.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Class\OldClassTableDef.msi" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Container\HarvestIntoDetachedContainer.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Container\MultipleAttachedContainers.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\CopyFile\CopyFile.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\CustomAction\SimpleCustomAction.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\CustomAction\CustomActionCycle.wxs" CopyToOutputDirectory="PreserveNewest" />
@@ -72,6 +74,7 @@
     <Content Include="TestData\MsiTransaction\X86AfterX64Bundle.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Payload\AbsoluteName.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Payload\CanonicalizeName.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\Payload\SharedBAAndPackagePayloadBundle.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Payload\ValidName.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\PatchFamilyFilter\.data\Av1.0.0.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\PatchFamilyFilter\.data\Av1.0.1.txt" CopyToOutputDirectory="PreserveNewest" />
@@ -187,6 +190,7 @@
     <Content Include="TestData\OverridableActions\Package.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\OverridableActions\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\OverridableActions\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\RollbackBoundary\BeginningOfChain.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\TextStyle\ColorNull.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\TextStyle\SizeLocalized.en-us.wxl" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\TextStyle\SizeLocalized.wxs" CopyToOutputDirectory="PreserveNewest" />

--- a/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -27,6 +27,7 @@
     <Content Include="TestData\BadInput\UnscheduledRollbackBoundary.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BindVariables\DefaultedVariable.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BindVariables\data\test.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\BootstrapperApplication\DpiAwareness.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BundleCustomTable\BundleCustomTable.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BundleExtension\BundleExtension.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\BundleExtension\BundleExtensionSearches.wxs" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
Implement command line for SuppressAllWarnings and WarningsAsError.
Make WixRunner.Execute default to setting WarningsAsError to make sure tests are not accidentally causing warnings.
Fix TryGetNextNonSwitchArgumentOrError.
Fix parsing of DpiAwareness attribute.

https://github.com/wixtoolset/issues/issues/5273
https://github.com/wixtoolset/issues/issues/6144
https://github.com/wixtoolset/issues/issues/6174 (already fixed in v4)