### PR TITLE
Issue#4753

### DIFF
--- a/src/WixToolset.Core/Compiler_2.cs
+++ b/src/WixToolset.Core/Compiler_2.cs
@@ -1576,7 +1576,6 @@ namespace WixToolset.Core
                         {
                             key = Path.Combine(parentKey, key);
                         }
-                        break;
                         // Issue #4753
                         // Unlike file paths, registry paths are not allowed to start or end with a backslash.
                         // Unless run as an administrator (i.e. with elevated privileges), keys that violate
@@ -1589,6 +1588,7 @@ namespace WixToolset.Core
                         {
                             key = key.Remove(key.Length - 1);
                         }
+                        break;
                     case "Root":
                         if (root.HasValue)
                         {

--- a/src/WixToolset.Core/Compiler_2.cs
+++ b/src/WixToolset.Core/Compiler_2.cs
@@ -1577,6 +1577,18 @@ namespace WixToolset.Core
                             key = Path.Combine(parentKey, key);
                         }
                         break;
+                        // Issue #4753
+                        // Unlike file paths, registry paths are not allowed to start or end with a backslash.
+                        // Unless run as an administrator (i.e. with elevated privileges), keys that violate
+                        // this rule results in ICE03 compiler errors. (Registry paths are not pre-evaluated
+                        // when running with elevated privileges.) Since many users include trailing backslashes
+                        // in registry paths, we are silently correcting this error here. If there are multiple
+                        // trailing slashes, removing the final one, as done here, will purposely still generate
+                        // the ICE03 error.
+                        if (null != key && key.EndsWith(@"\"))
+                        {
+                            key = key.Remove(key.Length - 1);
+                        }
                     case "Root":
                         if (root.HasValue)
                         {

--- a/src/WixToolset.Core/Compiler_2.cs
+++ b/src/WixToolset.Core/Compiler_2.cs
@@ -1576,14 +1576,6 @@ namespace WixToolset.Core
                         {
                             key = Path.Combine(parentKey, key);
                         }
-                        // Issue #4753
-                        // Unlike file paths, registry paths are not allowed to start or end with a backslash.
-                        // Unless run as an administrator (i.e. with elevated privileges), keys that violate
-                        // this rule results in ICE03 compiler errors. (Registry paths are not pre-evaluated
-                        // when running with elevated privileges.) Since many users include trailing backslashes
-                        // in registry paths, we are silently correcting this error here. If there are multiple
-                        // trailing slashes, removing the final one, as done here, will purposely still generate
-                        // the ICE03 error.
                         if (null != key && key.EndsWith(@"\"))
                         {
                             key = key.Remove(key.Length - 1);

--- a/src/test/WixToolsetTest.CoreIntegration/RegistryFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/RegistryFixture.cs
@@ -111,7 +111,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4753")]
+        [Fact]
         public void PopulatesRegistryTableWithoutExtraBackslash()
         {
             var folder = TestData.Get(@"TestData");


### PR DESCRIPTION
I have researched all aspects of this change, and believe it to be sound. I don't think there were any stylistic issues over which I
might have stumbled, but please let me know if I missed anything.

I've had more trouble interacting with git than with the Wix code. Please accept this as my first pull request.

The following comments are from Compiler_2.cs, line 1580 et. seq, and should presumably be removed before merging:

                        // Issue #4753
                        // Unlike file paths, registry paths are not allowed to start or end with a backslash.
                        // Unless run as an administrator (i.e. with elevated privileges), keys that violate
                        // this rule results in ICE03 compiler errors. (Registry paths are not pre-evaluated
                        // when running with elevated privileges.) Since many users include trailing backslashes
                        // in registry paths, we are silently correcting this error here. If there are multiple
                        // trailing slashes, removing the final one, as done here, will purposely still generate
                        // the ICE03 error.

Ron Martin