### PR TITLE
Removes all trailing backslashes from registry paths.

### DIFF
--- a/src/WixToolset.Core/Compiler_2.cs
+++ b/src/WixToolset.Core/Compiler_2.cs
@@ -1576,6 +1576,7 @@ namespace WixToolset.Core
                         {
                             key = Path.Combine(parentKey, key);
                         }
+                        key = key?.TrimEnd('\\');
                         break;
                     case "Root":
                         if (root.HasValue)

--- a/src/test/WixToolsetTest.CoreIntegration/RegistryFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/RegistryFixture.cs
@@ -111,7 +111,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4753")]
+        [Fact]
         public void PopulatesRegistryTableWithoutExtraBackslash()
         {
             var folder = TestData.Get(@"TestData");


### PR DESCRIPTION
 Fixes wixtoolset/issues#4753