### PR TITLE
Fix WixVariable resolution for paths

### DIFF
--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/PackageComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/PackageComponents.wxs
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
+        <Binary Id="Test.txt" SourceFile="!(wix.TestFile=test.txt)" />
         <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
             <Component>
                 <File Source="test.txt" />

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/PackageOverride.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/PackageOverride.wxs
@@ -1,0 +1,21 @@
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
+    
+
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+
+    <Feature Id="ProductFeature" Title="!(loc.FeatureTitle)">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+
+    <WixVariable Id="TestFile" Value="test2.txt" />
+  </Package>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/data/test2.txt
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/data/test2.txt
@@ -1,0 +1,1 @@
+This is test2.txt.


### PR DESCRIPTION
WixVariable resolution for paths wasn't working properly when linking with Wix library containing an embedded file.
The classic example is when it's necessary to override ThemeFile and LocalizationFile in WixStandardBootstrapperApplication.
Despite that new files were specified the ones embedded into the wixlib were used.