### PR TITLE
Add default rollback boundary in the Burn binder instead of the compiler

### DIFF
--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -357,10 +357,7 @@ namespace WixToolset.Core.Burn
             IEnumerable<PackageFacade> orderedFacades;
             IEnumerable<WixBundleRollbackBoundarySymbol> boundaries;
             {
-                var groupSymbols = section.Symbols.OfType<WixGroupSymbol>();
-                var boundarySymbolsById = section.Symbols.OfType<WixBundleRollbackBoundarySymbol>().ToDictionary(b => b.Id.Id);
-
-                var command = new OrderPackagesAndRollbackBoundariesCommand(this.Messaging, groupSymbols, boundarySymbolsById, facades);
+                var command = new OrderPackagesAndRollbackBoundariesCommand(this.Messaging, section, facades);
                 command.Execute();
 
                 orderedFacades = command.OrderedPackageFacades;

--- a/src/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/WixToolset.Core/Compiler_Bundle.cs
@@ -1726,11 +1726,8 @@ namespace WixToolset.Core
                 }
             }
 
-            // Ensure there is always a rollback boundary at the beginning of the chain.
-            this.CreateRollbackBoundary(sourceLineNumbers, new Identifier(AccessModifier.Global, "WixDefaultBoundary"), YesNoType.Yes, YesNoType.No, ComplexReferenceParentType.PackageGroup, "WixChain", ComplexReferenceChildType.Unknown, null);
-
-            var previousId = "WixDefaultBoundary";
-            var previousType = ComplexReferenceChildType.Package;
+            string previousId = null;
+            var previousType = ComplexReferenceChildType.Unknown;
 
             foreach (var child in node.Elements())
             {

--- a/src/test/WixToolsetTest.CoreIntegration/RollbackBoundaryFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/RollbackBoundaryFixture.cs
@@ -9,7 +9,7 @@ namespace WixToolsetTest.CoreIntegration
 
     public class RollbackBoundaryFixture
     {
-        [Fact(Skip = "Test demonstrates failure")]
+        [Fact]
         public void CanStartChainWithRollbackBoundary()
         {
             var folder = TestData.Get(@"TestData");


### PR DESCRIPTION
Fixes wixtoolset/issues#6312