### PR TITLE
Introduce Subdirectory and StandardDirectory

### DIFF
--- a/src/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -513,7 +513,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 targetName = ".";
             }
 
-            var defaultDir = String.IsNullOrEmpty(sourceName) ? targetName : targetName + ":" + sourceName;
+            var defaultDir = String.IsNullOrEmpty(sourceName) || sourceName == targetName ? targetName : targetName + ":" + sourceName;
 
             var row = this.CreateRow(symbol, "Directory");
             row[0] = symbol.Id.Id;

--- a/src/WixToolset.Core.WindowsInstaller/Decompile/Names.cs
+++ b/src/WixToolset.Core.WindowsInstaller/Decompile/Names.cs
@@ -69,6 +69,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
 
         public static readonly XName LevelElement = WxsNamespace + "Level";
         public static readonly XName DialogElement = WxsNamespace + "Dialog";
+        public static readonly XName StandardDirectoryElement = WxsNamespace + "StandardDirectory";
         public static readonly XName DirectoryElement = WxsNamespace + "Directory";
         public static readonly XName DirectorySearchElement = WxsNamespace + "DirectorySearch";
         public static readonly XName CopyFileElement = WxsNamespace + "CopyFile";

--- a/src/WixToolset.Core/CompilerCore.cs
+++ b/src/WixToolset.Core/CompilerCore.cs
@@ -386,13 +386,12 @@ namespace WixToolset.Core
         /// Creates directories using the inline directory syntax.
         /// </summary>
         /// <param name="sourceLineNumbers">Source line information.</param>
-        /// <param name="attribute">Attribute containing the inline syntax.</param>
         /// <param name="parentId">Optional identifier of parent directory.</param>
         /// <param name="inlineSyntax">Optional inline syntax to override attribute's value.</param>
         /// <returns>Identifier of the leaf directory created.</returns>
-        public string CreateDirectoryReferenceFromInlineSyntax(SourceLineNumber sourceLineNumbers, XAttribute attribute, string parentId, string inlineSyntax = null)
+        public string CreateDirectoryReferenceFromInlineSyntax(SourceLineNumber sourceLineNumbers, string parentId, string inlineSyntax = null)
         {
-            return this.parseHelper.CreateDirectoryReferenceFromInlineSyntax(this.ActiveSection, sourceLineNumbers, attribute, parentId, inlineSyntax, this.activeSectionCachedInlinedDirectoryIds);
+            return this.parseHelper.CreateDirectoryReferenceFromInlineSyntax(this.ActiveSection, sourceLineNumbers, attribute: null, parentId, inlineSyntax, this.activeSectionCachedInlinedDirectoryIds);
         }
 
         /// <summary>
@@ -784,7 +783,7 @@ namespace WixToolset.Core
         /// <param name="attribute">The attribute containing the value to get.</param>
         /// <param name="allowWildcards">true if wildcards are allowed in the filename.</param>
         /// <returns>The attribute's short filename value.</returns>
-        public string GetAttributeShortFilename(SourceLineNumber sourceLineNumbers, XAttribute attribute, bool allowWildcards)
+        public string GetAttributeShortFilename(SourceLineNumber sourceLineNumbers, XAttribute attribute, bool allowWildcards = false)
         {
             if (null == attribute)
             {
@@ -1019,16 +1018,6 @@ namespace WixToolset.Core
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Adds inline directory syntax generated identifier.
-        /// </summary>
-        /// <param name="inlineSyntax">Inline directory syntax the identifier was generated.</param>
-        /// <param name="id">Generated identifier for inline syntax.</param>
-        internal void AddInlineDirectoryId(string inlineSyntax, string id)
-        {
-            this.activeSectionCachedInlinedDirectoryIds.Add(inlineSyntax, id);
         }
 
         /// <summary>

--- a/src/WixToolset.Core/CompilerWarnings.cs
+++ b/src/WixToolset.Core/CompilerWarnings.cs
@@ -6,6 +6,16 @@ namespace WixToolset.Core
 
     internal static class CompilerWarnings
     {
+        public static Message DirectoryRefStandardDirectoryDeprecated(SourceLineNumber sourceLineNumbers, string directoryId)
+        {
+            return Message(sourceLineNumbers, Ids.DirectoryRefStandardDirectoryDeprecated, "Using DirectoryRef to reference the standard directory '{0}' is deprecated. Use the StandardDirectory element instead.", directoryId);
+        }
+
+        public static Message DefiningStandardDirectoryDeprecated(SourceLineNumber sourceLineNumbers, string directoryId)
+        {
+            return Message(sourceLineNumbers, Ids.DefiningStandardDirectoryDeprecated, "It is no longer necessary to define the standard directory '{0}'. Use the StandardDirectory element instead.", directoryId);
+        }
+
         public static Message DiscouragedVersionAttribute(SourceLineNumber sourceLineNumbers)
         {
             return Message(sourceLineNumbers, Ids.DiscouragedVersionAttribute, "The Provides/@Version attribute should not be specified in an MSI package. The ProductVersion will be used by default.");
@@ -48,6 +58,8 @@ namespace WixToolset.Core
             PropertyRemoved = 5433,
             DiscouragedVersionAttribute = 5434,
             Win64Component = 5435,
+            DirectoryRefStandardDirectoryDeprecated = 5436,
+            DefiningStandardDirectoryDeprecated = 5437,
         }
     }
 }

--- a/src/WixToolset.Core/Compiler_Module.cs
+++ b/src/WixToolset.Core/Compiler_Module.cs
@@ -203,6 +203,9 @@ namespace WixToolset.Core
                             string parentName = null;
                             this.ParseSFPCatalogElement(child, ref parentName);
                             break;
+                        case "StandardDirectory":
+                            this.ParseStandardDirectoryElement(child);
+                            break;
                         case "Substitution":
                             this.ParseSubstitutionElement(child);
                             break;

--- a/src/WixToolset.Core/Compiler_Package.cs
+++ b/src/WixToolset.Core/Compiler_Package.cs
@@ -316,6 +316,9 @@ namespace WixToolset.Core
                         case "SoftwareTag":
                             this.ParsePackageTagElement(child);
                             break;
+                        case "StandardDirectory":
+                            this.ParseStandardDirectoryElement(child);
+                            break;
                         case "SummaryInformation":
                             this.ParseSummaryInformationElement(child, ref isCodepageSet, ref isPackageNameSet, ref isKeywordsSet, ref isPackageAuthorSet);
                             break;

--- a/src/WixToolset.Core/Compiler_Package.cs
+++ b/src/WixToolset.Core/Compiler_Package.cs
@@ -2146,11 +2146,12 @@ namespace WixToolset.Core
         {
             var sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
             Identifier id = null;
-            string directory = null;
+            string directoryId = null;
+            string subdirectory = null;
             string name = null;
             bool? onInstall = null;
             bool? onUninstall = null;
-            string property = null;
+            string propertyId = null;
             string shortName = null;
 
             foreach (var attrib in node.Attributes())
@@ -2163,7 +2164,11 @@ namespace WixToolset.Core
                         id = this.Core.GetAttributeIdentifier(sourceLineNumbers, attrib);
                         break;
                     case "Directory":
-                        directory = this.Core.CreateDirectoryReferenceFromInlineSyntax(sourceLineNumbers, attrib, parentDirectory);
+                        directoryId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.Directory, directoryId);
+                        break;
+                    case "Subdirectory":
+                        directoryId = this.Core.GetAttributeLongFilename(sourceLineNumbers, attrib, allowRelative: true);
                         break;
                     case "Name":
                         name = this.Core.GetAttributeLongFilename(sourceLineNumbers, attrib, true);
@@ -2185,7 +2190,7 @@ namespace WixToolset.Core
                         }
                         break;
                     case "Property":
-                        property = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        propertyId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
                         break;
                     case "ShortName":
                         shortName = this.Core.GetAttributeShortFilename(sourceLineNumbers, attrib, true);
@@ -2211,15 +2216,23 @@ namespace WixToolset.Core
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "On"));
             }
 
-            if (null != directory && null != property)
+            if (String.IsNullOrEmpty(propertyId))
             {
-                this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "Property", "Directory", directory));
+                directoryId = this.HandleSubdirectory(sourceLineNumbers, node, directoryId ?? parentDirectory, subdirectory, "Directory", "Subdirectory");
+            }
+            else if (!String.IsNullOrEmpty(directoryId))
+            {
+                this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "Property", "Directory", directoryId));
+            }
+            else if (!String.IsNullOrEmpty(subdirectory))
+            {
+                this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "Property", "Subdirectory", subdirectory));
             }
 
             if (null == id)
             {
                 var on = (onInstall == true && onUninstall == true) ? 3 : (onUninstall == true) ? 2 : (onInstall == true) ? 1 : 0;
-                id = this.Core.CreateIdentifier("rmf", directory ?? property ?? parentDirectory, LowercaseOrNull(shortName), LowercaseOrNull(name), on.ToString());
+                id = this.Core.CreateIdentifier("rmf", directoryId ?? propertyId ?? parentDirectory, LowercaseOrNull(shortName), LowercaseOrNull(name), on.ToString());
             }
 
             this.Core.ParseForExtensionElements(node);
@@ -2231,7 +2244,7 @@ namespace WixToolset.Core
                     ComponentRef = componentId,
                     FileName = name,
                     ShortFileName = shortName,
-                    DirPropertyRef = directory ?? property ?? parentDirectory,
+                    DirPropertyRef = directoryId ?? propertyId ?? parentDirectory,
                     OnInstall = onInstall,
                     OnUninstall = onUninstall,
                 });
@@ -2248,10 +2261,11 @@ namespace WixToolset.Core
         {
             var sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
             Identifier id = null;
-            string directory = null;
+            string directoryId = null;
+            string subdirectory = null;
             bool? onInstall = null;
             bool? onUninstall = null;
-            string property = null;
+            string propertyId = null;
 
             foreach (var attrib in node.Attributes())
             {
@@ -2263,7 +2277,11 @@ namespace WixToolset.Core
                         id = this.Core.GetAttributeIdentifier(sourceLineNumbers, attrib);
                         break;
                     case "Directory":
-                        directory = this.Core.CreateDirectoryReferenceFromInlineSyntax(sourceLineNumbers, attrib, parentDirectory);
+                        directoryId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.Directory, directoryId);
+                        break;
+                    case "Subdirectory":
+                        subdirectory = this.Core.GetAttributeLongFilename(sourceLineNumbers, attrib, allowRelative: true);
                         break;
                     case "On":
                         var onValue = this.Core.GetAttributeValue(sourceLineNumbers, attrib);
@@ -2282,7 +2300,7 @@ namespace WixToolset.Core
                         }
                         break;
                     case "Property":
-                        property = this.Core.GetAttributeValue(sourceLineNumbers, attrib);
+                        propertyId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
                         break;
                     default:
                         this.Core.UnexpectedAttribute(node, attrib);
@@ -2300,15 +2318,23 @@ namespace WixToolset.Core
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "On"));
             }
 
-            if (null != directory && null != property)
+            if (String.IsNullOrEmpty(propertyId))
             {
-                this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "Property", "Directory", directory));
+                directoryId = this.HandleSubdirectory(sourceLineNumbers, node, directoryId ?? parentDirectory, subdirectory, "Directory", "Subdirectory");
+            }
+            else if (!String.IsNullOrEmpty(directoryId))
+            {
+                this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "Property", "Directory", directoryId));
+            }
+            else if (!String.IsNullOrEmpty(subdirectory))
+            {
+                this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "Property", "Subdirectory", subdirectory));
             }
 
             if (null == id)
             {
                 var on = (onInstall == true && onUninstall == true) ? 3 : (onUninstall == true) ? 2 : (onInstall == true) ? 1 : 0;
-                id = this.Core.CreateIdentifier("rmf", directory ?? property ?? parentDirectory, on.ToString());
+                id = this.Core.CreateIdentifier("rmf", directoryId ?? propertyId, on.ToString());
             }
 
             this.Core.ParseForExtensionElements(node);
@@ -2318,7 +2344,7 @@ namespace WixToolset.Core
                 this.Core.AddSymbol(new RemoveFileSymbol(sourceLineNumbers, id)
                 {
                     ComponentRef = componentId,
-                    DirPropertyRef = directory ?? property ?? parentDirectory,
+                    DirPropertyRef = directoryId ?? propertyId,
                     OnInstall = onInstall,
                     OnUninstall = onUninstall
                 });
@@ -2335,6 +2361,7 @@ namespace WixToolset.Core
         {
             var sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
             Identifier id = null;
+            string subdirectory = null;
             var runFromSource = CompilerConstants.IntegerNotSet;
             var runLocal = CompilerConstants.IntegerNotSet;
 
@@ -2348,7 +2375,11 @@ namespace WixToolset.Core
                         id = this.Core.GetAttributeIdentifier(sourceLineNumbers, attrib);
                         break;
                     case "Directory":
-                        directoryId = this.Core.CreateDirectoryReferenceFromInlineSyntax(sourceLineNumbers, attrib, directoryId);
+                        directoryId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.Directory, directoryId);
+                        break;
+                    case "Subdirectory":
+                        subdirectory = this.Core.GetAttributeLongFilename(sourceLineNumbers, attrib, allowRelative: true);
                         break;
                     case "RunFromSource":
                         runFromSource = this.Core.GetAttributeIntegerValue(sourceLineNumbers, attrib, 0, Int32.MaxValue);
@@ -2366,6 +2397,8 @@ namespace WixToolset.Core
                     this.Core.ParseExtensionAttribute(node, attrib);
                 }
             }
+
+            directoryId = this.HandleSubdirectory(sourceLineNumbers, node, directoryId, subdirectory, "Directory", "Subdirectory");
 
             if (null == id)
             {
@@ -4001,7 +4034,8 @@ namespace WixToolset.Core
             string description = null;
             string descriptionResourceDll = null;
             int? descriptionResourceId = null;
-            string directory = null;
+            string directoryId = null;
+            string subdirectory = null;
             string displayResourceDll = null;
             int? displayResourceId = null;
             int? hotkey = null;
@@ -4011,7 +4045,8 @@ namespace WixToolset.Core
             string shortName = null;
             ShortcutShowType? show = null;
             string target = null;
-            string workingDirectory = null;
+            string workingDirectoryId = null;
+            string workingSubdirectory = null;
 
             foreach (var attrib in node.Attributes())
             {
@@ -4038,7 +4073,11 @@ namespace WixToolset.Core
                         descriptionResourceId = this.Core.GetAttributeIntegerValue(sourceLineNumbers, attrib, 0, Int16.MaxValue);
                         break;
                     case "Directory":
-                        directory = this.Core.CreateDirectoryReferenceFromInlineSyntax(sourceLineNumbers, attrib, null);
+                        directoryId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.Directory, directoryId);
+                        break;
+                    case "Subdirectory":
+                        subdirectory = this.Core.GetAttributeLongFilename(sourceLineNumbers, attrib, allowRelative: true);
                         break;
                     case "DisplayResourceDll":
                         displayResourceDll = this.Core.GetAttributeValue(sourceLineNumbers, attrib);
@@ -4086,7 +4125,11 @@ namespace WixToolset.Core
                         target = this.Core.GetAttributeValue(sourceLineNumbers, attrib);
                         break;
                     case "WorkingDirectory":
-                        workingDirectory = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        workingDirectoryId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.Directory, workingDirectoryId);
+                        break;
+                    case "WorkingSubdirectory":
+                        workingSubdirectory = this.Core.GetAttributeLongFilename(sourceLineNumbers, attrib, allowRelative: true);
                         break;
                     default:
                         this.Core.UnexpectedAttribute(node, attrib);
@@ -4104,17 +4147,19 @@ namespace WixToolset.Core
                 this.Core.Write(ErrorMessages.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name.LocalName, "Target", "Advertise", "yes"));
             }
 
-            if (null == directory)
+            if (null == directoryId)
             {
                 if ("Component" == parentElementLocalName)
                 {
-                    directory = defaultTarget;
+                    directoryId = defaultTarget;
                 }
                 else
                 {
                     this.Core.Write(ErrorMessages.ExpectedAttributeWhenElementNotUnderElement(sourceLineNumbers, node.Name.LocalName, "Directory", "Component"));
                 }
             }
+
+            directoryId = this.HandleSubdirectory(sourceLineNumbers, node, directoryId, subdirectory, "Directory", "Subdirectory");
 
             if (null != descriptionResourceDll)
             {
@@ -4151,6 +4196,8 @@ namespace WixToolset.Core
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "Name"));
             }
 
+            workingDirectoryId = this.HandleSubdirectory(sourceLineNumbers, node, workingDirectoryId, workingSubdirectory, "WorkingDirectory", "WorkingSubdirectory");
+
             if ("Component" != parentElementLocalName && null != target)
             {
                 this.Core.Write(ErrorMessages.IllegalAttributeWhenNested(sourceLineNumbers, node.Name.LocalName, "Target", parentElementLocalName));
@@ -4158,7 +4205,7 @@ namespace WixToolset.Core
 
             if (null == id)
             {
-                id = this.Core.CreateIdentifier("sct", directory, LowercaseOrNull(name));
+                id = this.Core.CreateIdentifier("sct", directoryId, LowercaseOrNull(name));
             }
 
             foreach (var child in node.Elements())
@@ -4209,7 +4256,7 @@ namespace WixToolset.Core
 
                 this.Core.AddSymbol(new ShortcutSymbol(sourceLineNumbers, id)
                 {
-                    DirectoryRef = directory,
+                    DirectoryRef = directoryId,
                     Name = name,
                     ShortName = shortName,
                     ComponentRef = componentId,
@@ -4220,7 +4267,7 @@ namespace WixToolset.Core
                     IconRef = icon,
                     IconIndex = iconIndex,
                     Show = show,
-                    WorkingDirectory = workingDirectory,
+                    WorkingDirectory = workingDirectoryId,
                     DisplayResourceDll = displayResourceDll,
                     DisplayResourceId = displayResourceId,
                     DescriptionResourceDll = descriptionResourceDll,
@@ -4309,7 +4356,8 @@ namespace WixToolset.Core
             var cost = CompilerConstants.IntegerNotSet;
             string description = null;
             var flags = 0;
-            string helpDirectory = null;
+            string helpDirectoryId = null;
+            string helpSubdirectory = null;
             var language = CompilerConstants.IntegerNotSet;
             var majorVersion = CompilerConstants.IntegerNotSet;
             var minorVersion = CompilerConstants.IntegerNotSet;
@@ -4346,7 +4394,11 @@ namespace WixToolset.Core
                         }
                         break;
                     case "HelpDirectory":
-                        helpDirectory = this.Core.CreateDirectoryReferenceFromInlineSyntax(sourceLineNumbers, attrib, null);
+                        helpDirectoryId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                        this.Core.CreateSimpleReference(sourceLineNumbers, SymbolDefinitions.Directory, helpDirectoryId);
+                        break;
+                    case "HelpSubdirectory":
+                        helpSubdirectory = this.Core.GetAttributeLongFilename(sourceLineNumbers, attrib, allowRelative: true);
                         break;
                     case "Hidden":
                         if (YesNoType.Yes == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib))
@@ -4393,6 +4445,8 @@ namespace WixToolset.Core
                 this.Core.Write(ErrorMessages.ExpectedAttribute(sourceLineNumbers, node.Name.LocalName, "Language"));
                 language = CompilerConstants.IllegalInteger;
             }
+
+            helpDirectoryId = this.HandleSubdirectory(sourceLineNumbers, node, helpDirectoryId, helpSubdirectory, "HelpDirectory", "HelpSubdirectory");
 
             // build up the typelib version string for the registry if the major or minor version was specified
             string registryVersion = null;
@@ -4488,7 +4542,7 @@ namespace WixToolset.Core
                         Language = language,
                         ComponentRef = componentId,
                         Description = description,
-                        DirectoryRef = helpDirectory,
+                        DirectoryRef = helpDirectoryId,
                         FeatureRef = Guid.Empty.ToString("B")
                     });
 
@@ -4534,10 +4588,10 @@ namespace WixToolset.Core
                 // HKCR\TypeLib\[ID]\[MajorVersion].[MinorVersion]\FLAGS, (Default) = [TypeLibFlags]
                 this.Core.CreateRegistryRow(sourceLineNumbers, RegistryRootType.ClassesRoot, String.Format(CultureInfo.InvariantCulture, @"TypeLib\{0}\{1}\FLAGS", id, registryVersion), null, flags.ToString(CultureInfo.InvariantCulture.NumberFormat), componentId);
 
-                if (null != helpDirectory)
+                if (null != helpDirectoryId)
                 {
                     // HKCR\TypeLib\[ID]\[MajorVersion].[MinorVersion]\HELPDIR, (Default) = [HelpDirectory]
-                    this.Core.CreateRegistryRow(sourceLineNumbers, RegistryRootType.ClassesRoot, String.Format(CultureInfo.InvariantCulture, @"TypeLib\{0}\{1}\HELPDIR", id, registryVersion), null, String.Concat("[", helpDirectory, "]"), componentId);
+                    this.Core.CreateRegistryRow(sourceLineNumbers, RegistryRootType.ClassesRoot, String.Format(CultureInfo.InvariantCulture, @"TypeLib\{0}\{1}\HELPDIR", id, registryVersion), null, String.Concat("[", helpDirectoryId, "]"), componentId);
                 }
             }
         }

--- a/src/WixToolset.Core/Linker.cs
+++ b/src/WixToolset.Core/Linker.cs
@@ -587,7 +587,6 @@ namespace WixToolset.Core
             {
                 var removeSymbols = new List<IntermediateSymbol>();
 
-                // Count down because we'll sometimes remove items from the list.
                 foreach (var symbol in section.Symbols)
                 {
                     // Only process the "grouping parents" such as FeatureGroup, ComponentGroup, Feature,

--- a/src/test/WixToolsetTest.CoreIntegration/DirectoryFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/DirectoryFixture.cs
@@ -7,6 +7,7 @@ namespace WixToolsetTest.CoreIntegration
     using WixBuildTools.TestSupport;
     using WixToolset.Core.TestPackage;
     using WixToolset.Data;
+    using WixToolset.Data.WindowsInstaller;
     using Xunit;
 
     public class DirectoryFixture
@@ -40,11 +41,11 @@ namespace WixToolsetTest.CoreIntegration
                 var dirSymbols = section.Symbols.OfType<WixToolset.Data.Symbols.DirectorySymbol>().ToList();
                 Assert.Equal(new[]
                 {
-                    "INSTALLFOLDER",
-                    "ProgramFiles6432Folder",
-                    "ProgramFilesFolder",
-                    "TARGETDIR"
-                }, dirSymbols.Select(d => d.Id.Id).ToArray());
+                    "INSTALLFOLDER:ProgramFiles6432Folder:MsiPackage",
+                    "ProgramFiles6432Folder:ProgramFilesFolder:.",
+                    "ProgramFilesFolder:TARGETDIR:PFiles",
+                    "TARGETDIR::SourceDir"
+                }, dirSymbols.OrderBy(d => d.Id.Id).Select(d => d.Id.Id + ":" + d.ParentDirectoryRef + ":" + d.Name).ToArray());
             }
         }
 
@@ -78,11 +79,11 @@ namespace WixToolsetTest.CoreIntegration
                 var dirSymbols = section.Symbols.OfType<WixToolset.Data.Symbols.DirectorySymbol>().ToList();
                 Assert.Equal(new[]
                 {
-                    "INSTALLFOLDER",
-                    "ProgramFiles6432Folder",
-                    "ProgramFiles64Folder",
-                    "TARGETDIR"
-                }, dirSymbols.Select(d => d.Id.Id).ToArray());
+                    "INSTALLFOLDER:ProgramFiles6432Folder:MsiPackage",
+                    "ProgramFiles6432Folder:ProgramFiles64Folder:.",
+                    "ProgramFiles64Folder:TARGETDIR:PFiles64",
+                    "TARGETDIR::SourceDir"
+                }, dirSymbols.OrderBy(d => d.Id.Id).Select(d => d.Id.Id + ":" + d.ParentDirectoryRef + ":" + d.Name).ToArray());
             }
         }
 
@@ -116,12 +117,14 @@ namespace WixToolsetTest.CoreIntegration
                 var dirSymbols = section.Symbols.OfType<WixToolset.Data.Symbols.DirectorySymbol>().ToList();
                 Assert.Equal(new[]
                 {
-                    "dirZsSsu81KcG46xXTwc4mTSZO5Zx4",
-                    "INSTALLFOLDER",
-                    "ProgramFiles6432Folder",
-                    "ProgramFiles64Folder",
-                    "TARGETDIR"
-                }, dirSymbols.Select(d => d.Id.Id).ToArray());
+                    "dZsSsu81KcG46xXTwc4mTSZO5Zx4:INSTALLFOLDER:dupe",
+                    "INSTALLFOLDER:ProgramFiles6432Folder:MsiPackage",
+                    "ProgramFiles6432Folder:ProgramFiles64Folder:.",
+                    "ProgramFiles64Folder:TARGETDIR:PFiles64",
+                    "TARGETDIR::SourceDir"
+                }, dirSymbols.OrderBy(d => d.Id.Id).Select(d => d.Id.Id + ":" + d.ParentDirectoryRef + ":" + d.Name).ToArray());
+            }
+        }
             }
         }
     }

--- a/src/test/WixToolsetTest.CoreIntegration/ExtensionFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/ExtensionFixture.cs
@@ -53,7 +53,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 Assert.True(File.Exists(Path.Combine(intermediateFolder, @"bin\extest.msi")));
                 Assert.True(File.Exists(Path.Combine(intermediateFolder, @"bin\extest.wixpdb")));
-                Assert.True(File.Exists(Path.Combine(intermediateFolder, @"bin\MsiPackage\example.txt")));
+                Assert.True(File.Exists(Path.Combine(intermediateFolder, @"bin\PFiles\MsiPackage\example.txt")));
 
                 var intermediate = Intermediate.Load(Path.Combine(intermediateFolder, @"bin\extest.wixpdb"));
                 var section = intermediate.Sections.Single();

--- a/src/test/WixToolsetTest.CoreIntegration/LanguageFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/LanguageFixture.cs
@@ -8,6 +8,7 @@ namespace WixToolsetTest.CoreIntegration
     using WixToolset.Core.TestPackage;
     using WixToolset.Data;
     using WixToolset.Data.Symbols;
+    using WixToolset.Data.WindowsInstaller;
     using Xunit;
 
     public class LanguageFixture
@@ -36,6 +37,14 @@ namespace WixToolsetTest.CoreIntegration
                 var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
                 var section = intermediate.Sections.Single();
 
+                var directorySymbols = section.Symbols.OfType<DirectorySymbol>();
+                Assert.Equal(new[]
+                {
+                    "INSTALLFOLDER:Example Corporation\\MsiPackage",
+                    "ProgramFilesFolder:PFiles",
+                    "TARGETDIR:SourceDir"
+                }, directorySymbols.OrderBy(s => s.Id.Id).Select(s => s.Id.Id + ":" + s.Name).ToArray());
+
                 var propertySymbol = section.Symbols.OfType<PropertySymbol>().Single(p => p.Id.Id == "ProductLanguage");
                 Assert.Equal("0", propertySymbol.Value);
 
@@ -44,6 +53,16 @@ namespace WixToolsetTest.CoreIntegration
 
                 var summaryCodepage = section.Symbols.OfType<SummaryInformationSymbol>().Single(s => s.PropertyId == SummaryInformationType.Codepage);
                 Assert.Equal("1252", summaryCodepage.Value);
+
+                var data = WindowsInstallerData.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
+                var directoryRows = data.Tables["Directory"].Rows;
+                Assert.Equal(new[]
+                {
+                    "d4EceYatXTyy8HXPt5B6DT9Rj.wE:u7-b4gch|Example Corporation",
+                    "INSTALLFOLDER:oekcr5lq|MsiPackage",
+                    "ProgramFilesFolder:PFiles",
+                    "TARGETDIR:SourceDir"
+                }, directoryRows.Select(r => r.FieldAsString(0) + ":" + r.FieldAsString(2)).ToArray());
             }
         }
 

--- a/src/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
@@ -68,7 +68,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.msi")));
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.wixpdb")));
-                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\MsiPackage\test.txt")));
+                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\PFiles\MsiPackage\test.txt")));
 
                 var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
                 var section = intermediate.Sections.Single();

--- a/src/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/MsiFixture.cs
@@ -40,7 +40,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.msi")));
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.wixpdb")));
-                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\MsiPackage\test.txt")));
+                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\PFiles\MsiPackage\test.txt")));
 
                 var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
 
@@ -240,7 +240,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.msi")));
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.wixpdb")));
-                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\MsiPackage\test.txt")));
+                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\PFiles\MsiPackage\test.txt")));
 
                 var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
                 var section = intermediate.Sections.Single();
@@ -351,7 +351,7 @@ namespace WixToolsetTest.CoreIntegration
                 var pdbPath = Path.Combine(intermediateFolder, @"bin\test.wixpdb");
                 Assert.True(File.Exists(Path.Combine(intermediateFolder, @"bin\test.msi")));
                 Assert.True(File.Exists(pdbPath));
-                Assert.True(File.Exists(Path.Combine(intermediateFolder, @"bin\MsiPackage\test.txt")));
+                Assert.True(File.Exists(Path.Combine(intermediateFolder, @"bin\PFiles\MsiPackage\test.txt")));
 
                 var intermediate = Intermediate.Load(pdbPath);
                 var section = intermediate.Sections.Single();
@@ -527,7 +527,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.msi")));
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.wixpdb")));
-                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\MsiPackage\test.txt")));
+                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\PFiles\MsiPackage\test.txt")));
 
                 var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
                 var section = intermediate.Sections.Single();
@@ -563,7 +563,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.msi")));
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.wixpdb")));
-                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\AssemblyMsiPackage\candle.exe")));
+                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\PFiles\AssemblyMsiPackage\candle.exe")));
 
                 var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
                 var section = intermediate.Sections.Single();
@@ -721,7 +721,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.msi")));
                 Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\test.wixpdb")));
-                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\MsiPackage\Foo.exe")));
+                Assert.True(File.Exists(Path.Combine(baseFolder, @"bin\PFiles\MsiPackage\Foo.exe")));
 
                 var intermediate = Intermediate.Load(Path.Combine(baseFolder, @"bin\test.wixpdb"));
                 var section = intermediate.Sections.Single();

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/AppSearch/DecompiledNestedDirSearchUnderRegSearch.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/AppSearch/DecompiledNestedDirSearchUnderRegSearch.wxs
@@ -1,14 +1,12 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Codepage="1252" Language="1033" Manufacturer="Example Corporation" Name="MsiPackage" UpgradeCode="{12E4699F-E774-4D05-8A01-5BDD41BBA127}" Version="1.0.0.0" ProductCode="{33C58183-7333-4257-AEFD-6705DA66E617}">
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="ykd0udtb">
-          <Component Id="test.txt" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
-            <File Id="test.txt" Name="test.txt" KeyPath="yes" Source="SourceDir\\MsiPackage\test.txt" />
-          </Component>
-        </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="ykd0udtb">
+        <Component Id="test.txt" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
+        <File Id="test.txt" Name="test.txt" KeyPath="yes" Source="MsiPackage\test.txt" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
     <Feature Id="ProductFeature" Level="1" Title="MsiPackageTitle">
       <ComponentRef Id="test.txt" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Assembly/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Assembly/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="AssemblyMsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -10,10 +10,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="AssemblyMsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="AssemblyMsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Class/DecompiledOldClassTableDef.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Class/DecompiledOldClassTableDef.wxs
@@ -1,20 +1,18 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Codepage="1252" Language="1033" Manufacturer="Example Corporation" Name="MsiPackage" UpgradeCode="{12E4699F-E774-4D05-8A01-5BDD41BBA127}" Version="1.0.0.0" ProductCode="{FE17A505-11A9-44D2-8D94-EB6BEAB8FF93}">
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
-          <Component Id="ProgIdComp" Guid="{5B3B3FC1-533D-4C29-BFB3-0E88B51E59D8}" Bitness="always32">
-            <Class Id="{F12A6F69-117F-471F-AE73-F8E74218F498}" Context="LocalServer32" Description="FakeClassF12A" Advertise="yes">
-              <ProgId Id="73E7DF7E-EFAC-4E11-90E2-6EBAEB8DE58D" Description="FakeClassF12A" Advertise="yes" />
-            </Class>
-            <File Id="filTki4JQ2gSapF7wK4K1vd.4mDSFQ" Name="ProgIdComp.txt" KeyPath="yes" ShortName="bnvvntsc.txt" Source="SourceDir\\MsiPackage\ProgIdComp.txt" />
-            <RegistryValue Id="regUIIK326nDZpkWHuexeF58EikQvA" Root="HKCR" Key="73E7DF7E-EFAC-4E11-90E2-6EBAEB8DE58D" Name="NoOpen" Value="NoOpen73E7" Type="string" />
-            <RegistryValue Id="regY1F4E2lvu_Up6gV6c3jeN5ukn8s" Root="HKCR" Key="CLSID\{F12A6F69-117F-471F-AE73-F8E74218F498}\LocalServer32" Name="ThreadingModel" Value="Apartment" Type="string" />
-            <RegistryValue Id="regvrhMurMp98anbQJkpgA8yJCefdM" Root="HKCR" Key="CLSID\{F12A6F69-117F-471F-AE73-F8E74218F498}\Version" Value="0.0.0.1" Type="string" />
-          </Component>
-        </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
+        <Component Id="ProgIdComp" Guid="{5B3B3FC1-533D-4C29-BFB3-0E88B51E59D8}" Bitness="always32">
+          <Class Id="{F12A6F69-117F-471F-AE73-F8E74218F498}" Context="LocalServer32" Description="FakeClassF12A" Advertise="yes">
+            <ProgId Id="73E7DF7E-EFAC-4E11-90E2-6EBAEB8DE58D" Description="FakeClassF12A" Advertise="yes" />
+          </Class>
+          <File Id="filTki4JQ2gSapF7wK4K1vd.4mDSFQ" Name="ProgIdComp.txt" KeyPath="yes" ShortName="bnvvntsc.txt" Source="MsiPackage\ProgIdComp.txt" />
+          <RegistryValue Id="regUIIK326nDZpkWHuexeF58EikQvA" Root="HKCR" Key="73E7DF7E-EFAC-4E11-90E2-6EBAEB8DE58D" Name="NoOpen" Value="NoOpen73E7" Type="string" />
+          <RegistryValue Id="regY1F4E2lvu_Up6gV6c3jeN5ukn8s" Root="HKCR" Key="CLSID\{F12A6F69-117F-471F-AE73-F8E74218F498}\LocalServer32" Name="ThreadingModel" Value="Apartment" Type="string" />
+          <RegistryValue Id="regvrhMurMp98anbQJkpgA8yJCefdM" Root="HKCR" Key="CLSID\{F12A6F69-117F-471F-AE73-F8E74218F498}\Version" Value="0.0.0.1" Type="string" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
     <Feature Id="ProductFeature" Level="1" Title="MsiPackageTitle">
       <ComponentRef Id="ProgIdComp" Primary="yes" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ComplexExampleExtension/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -15,10 +15,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Components/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Components/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -10,10 +10,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/CopyFile/CopyFile.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/CopyFile/CopyFile.wxs
@@ -10,6 +10,8 @@
     </Fragment>
 
     <Fragment>
-        <Directory Id="OtherFolder" Name="INSTALLFOLDER:\other" />
+        <DirectoryRef Id="INSTALLFOLDER">
+            <Directory Id="OtherFolder" Name="other" />
+        </DirectoryRef>
     </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/CustomTable/CustomTable-Expected.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/CustomTable/CustomTable-Expected.wxs
@@ -12,17 +12,14 @@
         <Data Column="Component_" Value="test.txt" />
       </Row>
     </CustomTable>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder" Name="PFiles">
-        <Directory Id="ProgramFiles6432Folder">
-          <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="1egc1laj">
-            <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
-              <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="SourceDir\PFiles\\MsiPackage\test.txt" />
-            </Component>
-          </Directory>
-        </Directory>
+    <StandardDirectory Id="ProgramFiles6432Folder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="1egc1laj">
+        <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
+          <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="MsiPackage\test.txt" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
+    <StandardDirectory Id="ProgramFilesFolder" />
     <Feature Id="ProductFeature" Level="1" Title="MsiPackageTitle">
       <ComponentRef Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/DecompileNullComponent/Expected.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/DecompileNullComponent/Expected.wxs
@@ -1,14 +1,12 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Codepage="65001" Language="1033" Manufacturer="Example Corporation" Name="MsiPackage" UpgradeCode="{047730A5-30FE-4A62-A520-DA9381B8226A}" Version="1.0.0.0" Compressed="yes" InstallerVersion="200" ProductCode="{6F9B5694-F0F1-437C-919B-0D2DAF2D9DEA}">
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
-          <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="" Bitness="always32">
-            <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="SourceDir\File\filcV1yrx0x8wJWj4qMzcH21jwkPko" />
-          </Component>
-        </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
+        <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="" Bitness="always32">
+          <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="SourceDir\File\filcV1yrx0x8wJWj4qMzcH21jwkPko" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
     <Feature Id="ProductFeature" Level="1" Title="MsiPackage">
       <ComponentRef Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/DecompileSingleFileCompressed/Expected.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/DecompileSingleFileCompressed/Expected.wxs
@@ -1,14 +1,12 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Codepage="65001" Language="1033" Manufacturer="Example Corporation" Name="MsiPackage" UpgradeCode="{047730A5-30FE-4A62-A520-DA9381B8226A}" Version="1.0.0.0" Compressed="yes" InstallerVersion="200" ProductCode="{6F9B5694-F0F1-437C-919B-0D2DAF2D9DEA}">
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
-          <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
-            <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="SourceDir\File\filcV1yrx0x8wJWj4qMzcH21jwkPko" />
-          </Component>
-        </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
+        <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
+          <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="SourceDir\File\filcV1yrx0x8wJWj4qMzcH21jwkPko" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
     <Feature Id="ProductFeature" Level="1" Title="MsiPackage">
       <ComponentRef Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/DecompileSingleFileCompressed64/Expected.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/DecompileSingleFileCompressed64/Expected.wxs
@@ -1,14 +1,12 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Codepage="65001" Language="1033" Manufacturer="Example Corporation" Name="MsiPackage" UpgradeCode="{047730A5-30FE-4A62-A520-DA9381B8226A}" Version="1.0.0.0" Compressed="yes" ProductCode="{C51B773A-B3BE-4F29-A8A9-549AAF7FF6EC}">
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFiles64Folder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
-          <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always64">
-            <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="SourceDir\File\filcV1yrx0x8wJWj4qMzcH21jwkPko" />
-          </Component>
-        </Directory>
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="oekcr5lq">
+        <Component Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always64">
+          <File Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" Name="test.txt" KeyPath="yes" Source="SourceDir\File\filcV1yrx0x8wJWj4qMzcH21jwkPko" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
     <Feature Id="ProductFeature" Level="1" Title="MsiPackage">
       <ComponentRef Id="filcV1yrx0x8wJWj4qMzcH21jwkPko" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Directory/DuplicateTargetSourceName.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Directory/DuplicateTargetSourceName.wxs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="BinFolder" />
+    </Fragment>
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="BinFolder" Name="bin" SourceName="bin" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Directory/Nested.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Directory/Nested.wxs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="BinFolder" />
+    </Fragment>
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="BinFolder" Name="Example Corporation\Test Product\bin" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/DuplicateDir/DuplicateDir.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/DuplicateDir/DuplicateDir.wxs
@@ -8,7 +8,7 @@
     </Fragment>
 
     <Fragment>
-        <ComponentGroup Id="GroupA" Directory="INSTALLFOLDER:\dupe">
+        <ComponentGroup Id="GroupA" Directory="INSTALLFOLDER" Subdirectory="dupe">
             <Component>
                 <File Name="a.txt" Source="test.txt" />
             </Component>
@@ -16,7 +16,7 @@
     </Fragment>
 
     <Fragment>
-        <ComponentGroup Id="GroupB" Directory="INSTALLFOLDER:\dupe">
+        <ComponentGroup Id="GroupB" Directory="INSTALLFOLDER" Subdirectory="dupe">
             <Component>
                 <File Name="b.txt" Source="test.txt" />
             </Component>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ErrorsInUI/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -13,10 +13,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ExampleExtension/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ExampleExtension/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -14,10 +14,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ForEach/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ForEach/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Language="1033" Version="1.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -12,10 +12,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/IncludePath/Package.wxs
@@ -11,10 +11,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/InstanceTransform/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/InstanceTransform/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -16,10 +16,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackageInstance" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackageInstance" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Language/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Language/Package.wxs
@@ -11,6 +11,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="INSTALLFOLDER" Name="ProgramFilesFolder:\MsiPackage" />
+    <DirectoryRef Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </DirectoryRef>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Language/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Language/Package.wxs
@@ -11,8 +11,8 @@
   </Package>
 
   <Fragment>
-    <DirectoryRef Id="ProgramFilesFolder">
-      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-    </DirectoryRef>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="Example Corporation\MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ManualUpgrade/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ManualUpgrade/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -17,10 +17,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Media/MultiMedia.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Media/MultiMedia.wxs
@@ -8,19 +8,19 @@
         <Media Id="2" Cabinet="cab2.cab" />
         
         <Feature Id="ProductFeature" Title="MsiPackageTitle">
-            <Component Directory="ProgramFilesFolder:\~MultiMedia" DiskId="1">
+            <Component Directory="ProgramFilesFolder" Subdirectory="~MultiMedia" DiskId="1">
                 <File Source="a1.txt" />
             </Component>
 
-            <Component Directory="ProgramFilesFolder:\~MultiMedia" DiskId="1">
+            <Component Directory="ProgramFilesFolder" Subdirectory="~MultiMedia" DiskId="1">
                 <File Source="a2.txt" />
             </Component>
 
-            <Component Directory="ProgramFilesFolder:\~MultiMedia" DiskId="2">
+            <Component Directory="ProgramFilesFolder" Subdirectory="~MultiMedia" DiskId="2">
                 <File Source="b2.txt" />
             </Component>
 
-            <Component Directory="ProgramFilesFolder:\~MultiMedia" DiskId="2">
+            <Component Directory="ProgramFilesFolder" Subdirectory="~MultiMedia" DiskId="2">
                 <File Source="b1.txt" />
             </Component>
         </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/MultiFileCompressed/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/MultiFileCompressed/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="yes" InstallerVersion="200" Scope="perMachine">
     
 
@@ -19,10 +19,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/OverridableActions/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/OverridableActions/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
         
 
@@ -41,10 +41,8 @@
     </Fragment>
 
     <Fragment Id="Directories">
-        <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFilesFolder">
-                <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-            </Directory>
-        </Directory>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
     </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/PatchNoFileChanges/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/PatchNoFileChanges/Package.wxs
@@ -4,7 +4,9 @@
     <MajorUpgrade DowngradeErrorMessage="Newer version already installed." />
     <MediaTemplate EmbedCab="yes" />
 
-    <Directory Id="INSTALLFOLDER" Name="ProgramFilesFolder:\~Test App" />
+    <DirectoryRef Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="~Test App" />
+    </DirectoryRef>
 
     <Feature Id="Main">
       <ComponentGroupRef Id="Components" />

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/PatchNoFileChanges/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/PatchNoFileChanges/Package.wxs
@@ -4,9 +4,9 @@
     <MajorUpgrade DowngradeErrorMessage="Newer version already installed." />
     <MediaTemplate EmbedCab="yes" />
 
-    <DirectoryRef Id="ProgramFilesFolder">
+    <StandardDirectory Id="ProgramFilesFolder">
       <Directory Id="INSTALLFOLDER" Name="~Test App" />
-    </DirectoryRef>
+    </StandardDirectory>
 
     <Feature Id="Main">
       <ComponentGroupRef Id="Components" />

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/PatchNonSpecific/PackageA/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/PatchNonSpecific/PackageA/Package.wxs
@@ -15,11 +15,9 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="~Test A" />
-      </Directory>
-    </Directory>
+      <StandardDirectory Id="ProgramFilesFolder">
+          <Directory Id="INSTALLFOLDER" Name="~Test A" />
+      </StandardDirectory>
   </Fragment>
 
   <Fragment>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/PatchSingle/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/PatchSingle/Package.wxs
@@ -1,15 +1,13 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="~Test Package" Version="$(var.V)" Manufacturer="Example Corporation" Language="1033" UpgradeCode="7d326855-e790-4a94-8611-5351f8321fca" Compressed="yes" Scope="perMachine" ProductCode="7d326855-e790-4a94-8611-5351f8321fca">
     
 
     <MajorUpgrade DowngradeErrorMessage="Newer version already installed." />
     <MediaTemplate EmbedCab="yes" />
 
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="~Test App" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="~Test A" />
+    </StandardDirectory>
 
     <Feature Id="Main">
       <ComponentGroupRef Id="Components" />

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProductTag/PackageWithTag.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProductTag/PackageWithTag.wxs
@@ -11,10 +11,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProductWithComponentGroupRef/Product.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProductWithComponentGroupRef/Product.wxs
@@ -9,8 +9,8 @@
     </Package>
 
     <Fragment>
-        <DirectoryRef Id="ProgramFiles6432Folder">
+        <StandardDirectory Id="ProgramFiles6432Folder">
             <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-        </DirectoryRef>
+        </StandardDirectory>
     </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProductWithComponentGroupRef/Product.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProductWithComponentGroupRef/Product.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="12E4699F-E774-4D05-8A01-5BDD41BBA127" Compressed="no" Scope="perMachine" ProductCode="83f9c623-26fe-42ab-951e-170022117f54">
 
         <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
@@ -9,6 +9,8 @@
     </Package>
 
     <Fragment>
-        <Directory Id="INSTALLFOLDER" Name="ProgramFiles6432Folder:\MsiPackage" />
+        <DirectoryRef Id="ProgramFiles6432Folder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </DirectoryRef>
     </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/ProgId/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="ProgId" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -10,10 +10,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/PublishComponent/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/PublishComponent/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
 
@@ -13,11 +13,9 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 
   <Fragment>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SameFileFolders/TestComponents.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SameFileFolders/TestComponents.wxs
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Fragment>
-    <ComponentGroup Id="ProductComponents">
-      <Component  Directory="INSTALLFOLDER:\a">
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Subdirectory="a">
         <File Source="a\test.txt" />
       </Component>
-      <Component  Directory="INSTALLFOLDER:\b">
+      <Component Subdirectory="b">
         <File Source="b\test.txt" />
       </Component>
-      <Component  Directory="INSTALLFOLDER:\c">
+      <Component Subdirectory="c">
         <File Source="c\test.txt" />
       </Component>
     </ComponentGroup>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SequenceTables/DecompiledSequenceTables.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SequenceTables/DecompiledSequenceTables.wxs
@@ -1,15 +1,13 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Codepage="1252" Language="1033" Manufacturer="Example Corporation" Name="MsiPackage" UpgradeCode="{12E4699F-E774-4D05-8A01-5BDD41BBA127}" Version="1.0.0.0" ProductCode="{74C29381-1915-4948-B8B4-5646806A0BD4}">
     <CustomAction Id="CustomAction2" Property="TestAdvtExecuteSequenceProperty" Value="1" />
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="ykd0udtb">
-          <Component Id="test.txt" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
-            <File Id="test.txt" Name="test.txt" KeyPath="yes" Source="SourceDir\\MsiPackage\test.txt" />
-          </Component>
-        </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="ykd0udtb">
+        <Component Id="test.txt" Guid="{E597A58A-03CB-50D8-93E3-DABA263F233A}" Bitness="always32">
+          <File Id="test.txt" Name="test.txt" KeyPath="yes" Source="MsiPackage\test.txt" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
     <Feature Id="ProductFeature" Level="1" Title="MsiPackageTitle">
       <ComponentRef Id="test.txt" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SetProperty/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SetProperty/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -12,10 +12,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Shortcut/DecompiledShortcuts.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Shortcut/DecompiledShortcuts.wxs
@@ -1,17 +1,15 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Codepage="1252" Language="1033" Manufacturer="Example Corporation" Name="MsiPackage" UpgradeCode="{12E4699F-E774-4D05-8A01-5BDD41BBA127}" Version="1.0.0.0" ProductCode="{6CA94D1D-B568-4ED6-9EBC-3534C85970BB}">
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="ykd0udtb">
-          <Component Id="ShortcutComp" Guid="{5B3B3FC1-533D-4C29-BFB3-0E88B51E59D8}" Bitness="always32">
-            <File Id="test.txt" Name="test.txt" KeyPath="yes" Source="SourceDir\\MsiPackage\test.txt" />
-            <Shortcut Id="FileTargetShortcut" Directory="INSTALLFOLDER" Name="FileTargetShortcut" ShortName="lm2tdtqp" Target="[#test.txt]" />
-            <Shortcut Id="CustomTargetShortcut" Directory="INSTALLFOLDER" Name="Planner" ShortName="PLANNER" Target="[INSTALLFOLDER]custom.target" />
-            <Shortcut Id="AdvtShortcut" Directory="INSTALLFOLDER" Name="AdvtShortcut" ShortName="mdbqel9r" Advertise="yes" />
-          </Component>
-        </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" ShortName="ykd0udtb">
+        <Component Id="ShortcutComp" Guid="{5B3B3FC1-533D-4C29-BFB3-0E88B51E59D8}" Bitness="always32">
+        <File Id="test.txt" Name="test.txt" KeyPath="yes" Source="MsiPackage\test.txt" />
+        <Shortcut Id="FileTargetShortcut" Directory="INSTALLFOLDER" Name="FileTargetShortcut" ShortName="lm2tdtqp" Target="[#test.txt]" />
+        <Shortcut Id="CustomTargetShortcut" Directory="INSTALLFOLDER" Name="Planner" ShortName="PLANNER" Target="[INSTALLFOLDER]custom.target" />
+        <Shortcut Id="AdvtShortcut" Directory="INSTALLFOLDER" Name="AdvtShortcut" ShortName="mdbqel9r" Advertise="yes" />
+        </Component>
       </Directory>
-    </Directory>
+    </StandardDirectory>
     <Feature Id="ProductFeature" Level="1" Title="MsiPackageTitle">
       <ComponentRef Id="ShortcutComp" Primary="yes" />
     </Feature>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleMerge/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SimpleMerge/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="yes" InstallerVersion="200" Scope="perMachine">
     
 
@@ -10,13 +10,11 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-          <Directory Id="INSTALLFOLDER" Name="MsiPackage">
-              <!--   -->
-              <Merge Id="TestMsm" Language="1033" SourceFile="test.msm" />
-          </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage">
+        <!--   -->
+        <Merge Id="TestMsm" Language="1033" SourceFile="test.msm" />
       </Directory>
-    </Directory>
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
     
 
@@ -10,10 +10,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFileCompressed/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/SingleFileCompressed/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="65001" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="yes" InstallerVersion="200" Scope="perMachine">
     
 
@@ -18,10 +18,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/UsingProvides/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/UsingProvides/Package.wxs
@@ -9,6 +9,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="INSTALLFOLDER" Name="ProgramFilesFolder:\MsiPackage" />
+    <DirectoryRef Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </DirectoryRef>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/UsingProvides/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/UsingProvides/Package.wxs
@@ -9,8 +9,8 @@
   </Package>
 
   <Fragment>
-    <DirectoryRef Id="ProgramFilesFolder">
+    <StandardDirectory Id="ProgramFilesFolder">
       <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-    </DirectoryRef>
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/WixVariableOverride/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/WixVariableOverride/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
 
 
@@ -12,10 +12,8 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-      </Directory>
-    </Directory>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/Package.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/Wixipl/Package.wxs
@@ -1,4 +1,4 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package Name="MsiPackage" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
         
 
@@ -12,10 +12,8 @@
     </Package>
 
     <Fragment>
-        <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFilesFolder">
-                <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-            </Directory>
-        </Directory>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
     </Fragment>
 </Wix>


### PR DESCRIPTION
Introduce "Subdirectory" which simplifies inline directory syntax
Introduce StandardDirectory for referencing standard directories
Discards source directory name when identical to target name


Closes wixtoolset/issues#4727
Closes wixtoolset/issues#6416
Fixes wixtoolset/issues#6418