### PR TITLE
Check for duplicate cache ID's.

### DIFF
--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -191,6 +191,8 @@ namespace WixToolset.Core.Burn
                 return;
             }
 
+            var duplicateCacheIdDetector = new Dictionary<string, SourceLineNumber>(StringComparer.InvariantCulture);
+
             // Process each package facade. Note this is likely to add payloads and other symbols so
             // note that any indexes created above may be out of date now.
             foreach (var facade in facades.Values)
@@ -199,7 +201,7 @@ namespace WixToolset.Core.Burn
                 {
                 case WixBundlePackageType.Exe:
                 {
-                    var command = new ProcessExePackageCommand(facade, payloadSymbols);
+                    var command = new ProcessExePackageCommand(this.Messaging, facade, payloadSymbols, duplicateCacheIdDetector);
                     command.Execute();
                 }
                 break;
@@ -242,6 +244,8 @@ namespace WixToolset.Core.Burn
                     BindBundleCommand.PopulatePackageVariableCache(facade.PackageSymbol, variableCache);
                 }
             }
+
+            duplicateCacheIdDetector = null;
 
             if (this.Messaging.EncounteredError)
             {

--- a/src/WixToolset.Core.Burn/Bundles/ProcessExePackageCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/ProcessExePackageCommand.cs
@@ -4,22 +4,27 @@ namespace WixToolset.Core.Burn.Bundles
 {
     using System;
     using System.Collections.Generic;
+    using WixToolset.Data;
     using WixToolset.Data.Symbols;
+    using WixToolset.Extensibility.Services;
 
     /// <summary>
     /// Initializes package state from the Exe contents.
     /// </summary>
     internal class ProcessExePackageCommand
     {
-        public ProcessExePackageCommand(PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols)
+        public ProcessExePackageCommand(IMessaging messaging, PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols, Dictionary<string, SourceLineNumber> duplicateCacheIdDetector)
         {
+            this.Messaging = messaging;
             this.AuthoredPayloads = payloadSymbols;
             this.Facade = facade;
+            this.DuplicateCacheIdDetector = duplicateCacheIdDetector;
         }
 
-        public Dictionary<string, WixBundlePayloadSymbol> AuthoredPayloads { get; }
-
+        public IMessaging Messaging { get; }
         public PackageFacade Facade { get; }
+        public Dictionary<string, WixBundlePayloadSymbol> AuthoredPayloads { get; }
+        public Dictionary<string, SourceLineNumber> DuplicateCacheIdDetector { get; }
 
         /// <summary>
         /// Processes the Exe packages to add properties and payloads from the Exe packages.
@@ -31,6 +36,16 @@ namespace WixToolset.Core.Burn.Bundles
             if (String.IsNullOrEmpty(this.Facade.PackageSymbol.CacheId))
             {
                 this.Facade.PackageSymbol.CacheId = packagePayload.Hash;
+            }
+
+            if (this.DuplicateCacheIdDetector.TryGetValue(this.Facade.PackageSymbol.CacheId, out var sourceLineNumber))
+            {
+                this.Messaging.Write(ErrorMessages.DuplicateCacheIds1(sourceLineNumber, this.Facade.PackageSymbol.CacheId));
+                this.Messaging.Write(ErrorMessages.DuplicateCacheIds2(this.Facade.PackageSymbol.SourceLineNumbers, this.Facade.PackageSymbol.CacheId));
+            }
+            else
+            {
+                this.DuplicateCacheIdDetector.Add(this.Facade.PackageSymbol.CacheId, this.Facade.PackageSymbol.SourceLineNumbers);
             }
 
             this.Facade.PackageSymbol.Version = packagePayload.Version;

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -280,7 +280,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4628")]
+        [Fact]
         public void CantBuildWithDuplicateCacheIds()
         {
             var folder = TestData.Get(@"TestData");
@@ -302,7 +302,7 @@ namespace WixToolsetTest.CoreIntegration
                     "-o", exePath,
                 });
 
-                Assert.InRange(result.ExitCode, 2, Int32.MaxValue);
+                Assert.Equal(result.ExitCode, (int)ErrorMessages.Ids.DuplicateCacheIds2);
             }
         }
 

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" CacheId="Manual" />
-            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" CacheId="Manual" />
+            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" DetectCondition="anything" CacheId="Manual" />
+            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" DetectCondition="anything" CacheId="Manual" />
         </PackageGroup>
     </Fragment>
 </Wix>


### PR DESCRIPTION
Issue a new error message each time a new duplicate cache ID is found. Each message refers to the original occurrence of the cache ID. Comparisons are case sensitive and culture insensitive. Cache ID's created from hashes are included in the process.

Fixes wixtoolset/issues#4628
