### PR TITLE
Check for duplicate cache ID's.

### DIFF
--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -191,6 +191,8 @@ namespace WixToolset.Core.Burn
                 return;
             }
 
+            var duplicateCacheIdDetector = new Dictionary<string, SourceLineNumber>(StringComparer.InvariantCulture);
+
             // Process each package facade. Note this is likely to add payloads and other symbols so
             // note that any indexes created above may be out of date now.
             foreach (var facade in facades.Values)
@@ -199,14 +201,14 @@ namespace WixToolset.Core.Burn
                 {
                 case WixBundlePackageType.Exe:
                 {
-                    var command = new ProcessExePackageCommand(facade, payloadSymbols);
+                    var command = new ProcessExePackageCommand(this.ServiceProvider, facade, payloadSymbols, duplicateCacheIdDetector);
                     command.Execute();
                 }
                 break;
 
                 case WixBundlePackageType.Msi:
                 {
-                    var command = new ProcessMsiPackageCommand(this.ServiceProvider, this.BackendExtensions, section, facade, packagesPayloads[facade.PackageId]);
+                    var command = new ProcessMsiPackageCommand(this.ServiceProvider, this.BackendExtensions, section, facade, packagesPayloads[facade.PackageId], duplicateCacheIdDetector);
                     command.Execute();
 
                     if (null != variableCache)
@@ -224,14 +226,14 @@ namespace WixToolset.Core.Burn
 
                 case WixBundlePackageType.Msp:
                 {
-                    var command = new ProcessMspPackageCommand(this.Messaging, section, facade, payloadSymbols);
+                    var command = new ProcessMspPackageCommand(this.ServiceProvider, section, facade, payloadSymbols, duplicateCacheIdDetector);
                     command.Execute();
                 }
                 break;
 
                 case WixBundlePackageType.Msu:
                 {
-                    var command = new ProcessMsuPackageCommand(facade, payloadSymbols);
+                    var command = new ProcessMsuPackageCommand(this.ServiceProvider, facade, payloadSymbols, duplicateCacheIdDetector);
                     command.Execute();
                 }
                 break;
@@ -242,6 +244,8 @@ namespace WixToolset.Core.Burn
                     BindBundleCommand.PopulatePackageVariableCache(facade.PackageSymbol, variableCache);
                 }
             }
+
+            duplicateCacheIdDetector = null;
 
             if (this.Messaging.EncounteredError)
             {

--- a/src/WixToolset.Core.Burn/Bundles/ProcessExePackageCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/ProcessExePackageCommand.cs
@@ -4,22 +4,19 @@ namespace WixToolset.Core.Burn.Bundles
 {
     using System;
     using System.Collections.Generic;
+    using WixToolset.Data;
     using WixToolset.Data.Symbols;
+    using WixToolset.Extensibility.Services;
 
     /// <summary>
     /// Initializes package state from the Exe contents.
     /// </summary>
-    internal class ProcessExePackageCommand
+    internal class ProcessExePackageCommand : ProcessPackageCommand
     {
-        public ProcessExePackageCommand(PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols)
-        {
-            this.AuthoredPayloads = payloadSymbols;
-            this.Facade = facade;
-        }
+        public ProcessExePackageCommand(IServiceProvider serviceProvider, PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols, Dictionary<string, SourceLineNumber> duplicateCacheIdDetector)
+        : base(serviceProvider, facade, duplicateCacheIdDetector) => this.AuthoredPayloads = payloadSymbols;
 
         public Dictionary<string, WixBundlePayloadSymbol> AuthoredPayloads { get; }
-
-        public PackageFacade Facade { get; }
 
         /// <summary>
         /// Processes the Exe packages to add properties and payloads from the Exe packages.
@@ -27,13 +24,14 @@ namespace WixToolset.Core.Burn.Bundles
         public void Execute()
         {
             var packagePayload = this.AuthoredPayloads[this.Facade.PackageSymbol.PayloadRef];
+            this.Facade.PackageSymbol.Version = packagePayload.Version;
 
             if (String.IsNullOrEmpty(this.Facade.PackageSymbol.CacheId))
             {
                 this.Facade.PackageSymbol.CacheId = packagePayload.Hash;
             }
 
-            this.Facade.PackageSymbol.Version = packagePayload.Version;
+            this.CheckForDuplicateCacheIds();
         }
     }
 }

--- a/src/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/ProcessMsiPackageCommand.cs
@@ -18,24 +18,21 @@ namespace WixToolset.Core.Burn.Bundles
     /// <summary>
     /// Initializes package state from the MSI contents.
     /// </summary>
-    internal class ProcessMsiPackageCommand
+    internal class ProcessMsiPackageCommand : ProcessPackageCommand
     {
         private const string PropertySqlQuery = "SELECT `Value` FROM `Property` WHERE `Property` = ?";
 
-        public ProcessMsiPackageCommand(IServiceProvider serviceProvider, IEnumerable<IBurnBackendBinderExtension> backendExtensions, IntermediateSection section, PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> packagePayloads)
+        public ProcessMsiPackageCommand(IServiceProvider serviceProvider, IEnumerable<IBurnBackendBinderExtension> backendExtensions, IntermediateSection section, PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> packagePayloads, Dictionary<string, SourceLineNumber> duplicateCacheIdDetector)
+        : base(serviceProvider, facade, duplicateCacheIdDetector)
         {
-            this.Messaging = serviceProvider.GetService<IMessaging>();
-            this.BackendHelper = serviceProvider.GetService<IBackendHelper>();
-            this.PathResolver = serviceProvider.GetService<IPathResolver>();
+            this.BackendHelper = this.ServiceProvider.GetService<IBackendHelper>();
+            this.PathResolver = this.ServiceProvider.GetService<IPathResolver>();
 
             this.BackendExtensions = backendExtensions;
 
             this.PackagePayloads = packagePayloads;
             this.Section = section;
-            this.Facade = facade;
         }
-
-        private IMessaging Messaging { get; }
 
         private IBackendHelper BackendHelper { get; }
 
@@ -44,8 +41,6 @@ namespace WixToolset.Core.Burn.Bundles
         private IEnumerable<IBurnBackendBinderExtension> BackendExtensions { get; }
 
         private Dictionary<string, WixBundlePayloadSymbol> PackagePayloads { get; }
-
-        private PackageFacade Facade { get; }
 
         private IntermediateSection Section { get; }
 
@@ -142,6 +137,8 @@ namespace WixToolset.Core.Burn.Bundles
                     {
                         this.Facade.PackageSymbol.CacheId = String.Format("{0}v{1}", msiPackage.ProductCode, msiPackage.ProductVersion);
                     }
+
+                    this.CheckForDuplicateCacheIds();
 
                     if (String.IsNullOrEmpty(this.Facade.PackageSymbol.DisplayName))
                     {

--- a/src/WixToolset.Core.Burn/Bundles/ProcessMspPackageCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/ProcessMspPackageCommand.cs
@@ -15,7 +15,7 @@ namespace WixToolset.Core.Burn.Bundles
     /// <summary>
     /// Initializes package state from the Msp contents.
     /// </summary>
-    internal class ProcessMspPackageCommand
+    internal class ProcessMspPackageCommand : ProcessPackageCommand
     {
         private const string PatchMetadataQuery = "SELECT `Value` FROM `MsiPatchMetadata` WHERE `Property` = ?";
         private static readonly XmlWriterSettings XmlSettings = new XmlWriterSettings()
@@ -26,20 +26,14 @@ namespace WixToolset.Core.Burn.Bundles
             NewLineHandling = NewLineHandling.Replace,
         };
 
-        public ProcessMspPackageCommand(IMessaging messaging, IntermediateSection section, PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols)
+        public ProcessMspPackageCommand(IServiceProvider serviceProvider, IntermediateSection section, PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols, Dictionary<string, SourceLineNumber> duplicateCacheIdDetector)
+            : base(serviceProvider, facade, duplicateCacheIdDetector)
         {
-            this.Messaging = messaging;
-
             this.AuthoredPayloads = payloadSymbols;
             this.Section = section;
-            this.Facade = facade;
         }
 
-        public IMessaging Messaging { get; }
-
         public Dictionary<string, WixBundlePayloadSymbol> AuthoredPayloads { private get; set; }
-
-        public PackageFacade Facade { private get; set; }
 
         public IntermediateSection Section { get; }
 
@@ -93,6 +87,8 @@ namespace WixToolset.Core.Burn.Bundles
             {
                 this.Facade.PackageSymbol.CacheId = mspPackage.PatchCode;
             }
+
+            this.CheckForDuplicateCacheIds();
         }
 
         private void ProcessPatchXml(WixBundlePayloadSymbol packagePayload, WixBundleMspPackageSymbol mspPackage, string sourcePath)

--- a/src/WixToolset.Core.Burn/Bundles/ProcessMsuPackageCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/ProcessMsuPackageCommand.cs
@@ -10,17 +10,12 @@ namespace WixToolset.Core.Burn.Bundles
     /// <summary>
     /// Processes the Msu packages to add properties and payloads from the Msu packages.
     /// </summary>
-    internal class ProcessMsuPackageCommand
+    internal class ProcessMsuPackageCommand : ProcessPackageCommand
     {
-        public ProcessMsuPackageCommand(PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols)
-        {
-            this.AuthoredPayloads = payloadSymbols;
-            this.Facade = facade;
-        }
+        public ProcessMsuPackageCommand(IServiceProvider serviceProvider, PackageFacade facade, Dictionary<string, WixBundlePayloadSymbol> payloadSymbols, Dictionary<string, SourceLineNumber> duplicateCacheIdDetector)
+            : base(serviceProvider, facade, duplicateCacheIdDetector) => this.AuthoredPayloads = payloadSymbols;
 
         public Dictionary<string, WixBundlePayloadSymbol> AuthoredPayloads { private get; set; }
-
-        public PackageFacade Facade { private get; set; }
 
         public void Execute()
         {
@@ -30,6 +25,8 @@ namespace WixToolset.Core.Burn.Bundles
             {
                 this.Facade.PackageSymbol.CacheId = packagePayload.Hash;
             }
+
+            this.CheckForDuplicateCacheIds();
 
             this.Facade.PackageSymbol.PerMachine = YesNoDefaultType.Yes; // MSUs are always per-machine.
         }

--- a/src/WixToolset.Core.Burn/Bundles/ProcessPackageCommand.cs
+++ b/src/WixToolset.Core.Burn/Bundles/ProcessPackageCommand.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+using WixToolset.Extensibility.Services;
+
+namespace WixToolset.Core.Burn.Bundles
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using WixToolset.Data;
+
+    internal class ProcessPackageCommand
+    {
+        public ProcessPackageCommand(IServiceProvider serviceProvider, PackageFacade facade, Dictionary<string, SourceLineNumber> duplicateCacheIdDetector)
+        {
+            this.ServiceProvider = serviceProvider;
+            this.Messaging = serviceProvider.GetService<IMessaging>();
+            this.Facade = facade;
+            this.DuplicateCacheIdDetector = duplicateCacheIdDetector;
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+        public IMessaging Messaging { get; }
+        public PackageFacade Facade { get; }
+        public Dictionary<string, SourceLineNumber> DuplicateCacheIdDetector { get; }
+
+        public void CheckForDuplicateCacheIds()
+        {
+            if (this.DuplicateCacheIdDetector.TryGetValue(this.Facade.PackageSymbol.CacheId, out var sourceLineNumber))
+            {
+                this.Messaging.Write(BurnBackendErrors.DuplicateCacheIds1(sourceLineNumber, this.Facade.PackageSymbol.CacheId));
+                this.Messaging.Write(BurnBackendErrors.DuplicateCacheIds2(this.Facade.PackageSymbol.SourceLineNumbers, this.Facade.PackageSymbol.CacheId));
+            }
+            else
+            {
+                this.DuplicateCacheIdDetector.Add(this.Facade.PackageSymbol.CacheId, this.Facade.PackageSymbol.SourceLineNumbers);
+            }
+        }
+    }
+}

--- a/src/WixToolset.Core.Burn/BurnBackendErrors.cs
+++ b/src/WixToolset.Core.Burn/BurnBackendErrors.cs
@@ -6,10 +6,15 @@ namespace WixToolset.Core.Burn
 
     internal static class BurnBackendErrors
     {
-        //public static Message ReplaceThisWithTheFirstError(SourceLineNumber sourceLineNumbers)
-        //{
-        //    return Message(sourceLineNumbers, Ids.ReplaceThisWithTheFirstError, "format string", arg1, arg2);
-        //}
+        public static Message DuplicateCacheIds1(SourceLineNumber originalLineNumber, string cacheId)
+        {
+            return Message(originalLineNumber, Ids.DuplicateCacheIds1, "The cache id '{0}' has been duplicated as indicated in the following message.", cacheId);
+        }
+
+        public static Message DuplicateCacheIds2(SourceLineNumber duplicateLineNumber, string cacheId)
+        {
+            return Message(duplicateLineNumber, Ids.DuplicateCacheIds2, "Each cache id must be unique. '{0}' has been used before as indicated in the previous message.", cacheId);
+        }
 
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
@@ -18,7 +23,8 @@ namespace WixToolset.Core.Burn
 
         public enum Ids
         {
-            // ReplaceThisWithTheFirstError = 8000,
+            DuplicateCacheIds1 = 8000,
+            DuplicateCacheIds2 = 8001,
         }
     }
 }

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -280,7 +280,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4628")]
+        [Fact]
         public void CantBuildWithDuplicateCacheIds()
         {
             var folder = TestData.Get(@"TestData");
@@ -302,7 +302,7 @@ namespace WixToolsetTest.CoreIntegration
                     "-o", exePath,
                 });
 
-                Assert.InRange(result.ExitCode, 2, Int32.MaxValue);
+                Assert.Equal(8001, result.ExitCode);
             }
         }
 

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" CacheId="Manual" />
-            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" CacheId="Manual" />
+            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" DetectCondition="anything" CacheId="Manual" />
+            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" DetectCondition="anything" CacheId="Manual" />
         </PackageGroup>
     </Fragment>
 </Wix>


### PR DESCRIPTION
Issue a new error message each time a new duplicate cache ID is found. Each message refers to the original occurrence of the cache ID. Comparisons are case sensitive and culture insensitive. Automatically generated Cache ID's are included in the process.

Fixes wixtoolset/issues#4628