### PR TITLE
Several fixes in Burn Backend

### DIFF
--- a/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/BindBundleCommand.cs
@@ -459,12 +459,18 @@ namespace WixToolset.Core.Burn
                 containers = command.Containers;
             }
 
+            // Resolve the download URLs now that we have all of the containers and payloads calculated.
+            {
+                var command = new ResolveDownloadUrlsCommand(this.Messaging, this.BackendExtensions, containers, payloadSymbols);
+                command.Execute();
+            }
+
             // Create the bundle manifest.
             string manifestPath;
             {
                 var executableName = Path.GetFileName(this.OutputPath);
 
-                var command = new CreateBurnManifestCommand(this.Messaging, this.BackendExtensions, executableName, section, bundleSymbol, containers, chainSymbol, orderedFacades, boundaries, uxPayloads, payloadSymbols, packagesPayloads, orderedSearches, this.IntermediateFolder);
+                var command = new CreateBurnManifestCommand(executableName, section, bundleSymbol, containers, chainSymbol, orderedFacades, boundaries, uxPayloads, payloadSymbols, packagesPayloads, orderedSearches, this.IntermediateFolder);
                 command.Execute();
 
                 manifestPath = command.OutputPath;

--- a/src/WixToolset.Core.Burn/Bind/ResolveDownloadUrlsCommand.cs
+++ b/src/WixToolset.Core.Burn/Bind/ResolveDownloadUrlsCommand.cs
@@ -1,0 +1,127 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core.Burn.Bind
+{
+    using System;
+    using System.Collections.Generic;
+    using WixToolset.Data;
+    using WixToolset.Data.Symbols;
+    using WixToolset.Extensibility;
+    using WixToolset.Extensibility.Services;
+
+    internal class ResolveDownloadUrlsCommand
+    {
+        public ResolveDownloadUrlsCommand(IMessaging messaging, IEnumerable<IBurnBackendBinderExtension> backendExtensions, IEnumerable<WixBundleContainerSymbol> containers, Dictionary<string, WixBundlePayloadSymbol> payloadsById)
+        {
+            this.Messaging = messaging;
+            this.BackendExtensions = backendExtensions;
+            this.Containers = containers;
+            this.PayloadsById = payloadsById;
+        }
+
+        private IMessaging Messaging { get; }
+
+        private IEnumerable<IBurnBackendBinderExtension> BackendExtensions { get; }
+
+        private IEnumerable<WixBundleContainerSymbol> Containers { get; }
+
+        private Dictionary<string, WixBundlePayloadSymbol> PayloadsById { get; }
+
+        public void Execute()
+        {
+            this.ResolveContainerUrls();
+
+            this.ResolvePayloadUrls();
+        }
+
+        private void ResolveContainerUrls()
+        {
+            foreach (var container in this.Containers)
+            {
+                if (container.Type == ContainerType.Detached)
+                {
+                    var resolvedUrl = this.ResolveUrl(container.DownloadUrl, null, null, container.Id.Id, container.Name);
+                    if (!String.IsNullOrEmpty(resolvedUrl))
+                    {
+                        container.DownloadUrl = resolvedUrl;
+                    }
+                }
+                else if (container.Type == ContainerType.Attached)
+                {
+                    if (!String.IsNullOrEmpty(container.DownloadUrl))
+                    {
+                        this.Messaging.Write(WarningMessages.DownloadUrlNotSupportedForAttachedContainers(container.SourceLineNumbers, container.Id.Id));
+                    }
+                }
+            }
+        }
+
+        private void ResolvePayloadUrls()
+        {
+            foreach (var payload in this.PayloadsById.Values)
+            {
+                if (payload.Packaging == PackagingType.External)
+                {
+                    var packageId = payload.ParentPackagePayloadRef;
+                    var parentUrl = payload.ParentPackagePayloadRef == null ? null : this.PayloadsById[payload.ParentPackagePayloadRef].DownloadUrl;
+                    var resolvedUrl = this.ResolveUrl(payload.DownloadUrl, parentUrl, packageId, payload.Id.Id, payload.Name);
+                    if (!String.IsNullOrEmpty(resolvedUrl))
+                    {
+                        payload.DownloadUrl = resolvedUrl;
+                    }
+                }
+                else if (payload.Packaging == PackagingType.Embedded)
+                {
+                    if (!String.IsNullOrEmpty(payload.DownloadUrl))
+                    {
+                        this.Messaging.Write(WarningMessages.DownloadUrlNotSupportedForEmbeddedPayloads(payload.SourceLineNumbers, payload.Id.Id));
+                    }
+                }
+            }
+        }
+
+        private string ResolveUrl(string url, string fallbackUrl, string packageId, string payloadId, string fileName)
+        {
+            string resolvedUrl = null;
+
+            foreach (var extension in this.BackendExtensions)
+            {
+                resolvedUrl = extension.ResolveUrl(url, fallbackUrl, packageId, payloadId, fileName);
+                if (!String.IsNullOrEmpty(resolvedUrl))
+                {
+                    break;
+                }
+            }
+
+            if (String.IsNullOrEmpty(resolvedUrl))
+            {
+                // If a URL was not specified but there is a fallback URL that has a format specifier in it
+                // then use the fallback URL formatter for this URL.
+                if (String.IsNullOrEmpty(url) && !String.IsNullOrEmpty(fallbackUrl))
+                {
+                    var formattedFallbackUrl = String.Format(fallbackUrl, packageId, payloadId, fileName);
+                    if (!String.Equals(fallbackUrl, formattedFallbackUrl, StringComparison.OrdinalIgnoreCase))
+                    {
+                        url = fallbackUrl;
+                    }
+                }
+
+                if (!String.IsNullOrEmpty(url))
+                {
+                    var formattedUrl = String.Format(url, packageId, payloadId, fileName);
+
+                    if (Uri.TryCreate(formattedUrl, UriKind.Absolute, out var canonicalUri))
+                    {
+                        resolvedUrl = canonicalUri.AbsoluteUri;
+                    }
+                    else
+                    {
+                        resolvedUrl = null;
+                    }
+                }
+            }
+
+            return resolvedUrl;
+        }
+    }
+}

--- a/src/WixToolset.Core.Burn/BurnBackendErrors.cs
+++ b/src/WixToolset.Core.Burn/BurnBackendErrors.cs
@@ -6,10 +6,15 @@ namespace WixToolset.Core.Burn
 
     internal static class BurnBackendErrors
     {
-        //public static Message ReplaceThisWithTheFirstError(SourceLineNumber sourceLineNumbers)
-        //{
-        //    return Message(sourceLineNumbers, Ids.ReplaceThisWithTheFirstError, "format string", arg1, arg2);
-        //}
+        public static Message DuplicateCacheIds(SourceLineNumber originalLineNumber, string cacheId)
+        {
+            return Message(originalLineNumber, Ids.DuplicateCacheIds, "The cache id '{0}' has been duplicated as indicated in the following message.", cacheId);
+        }
+
+        public static Message DuplicateCacheIds2(SourceLineNumber duplicateLineNumber, string cacheId)
+        {
+            return Message(duplicateLineNumber, Ids.DuplicateCacheIds2, "Each cache id must be unique. '{0}' has been used before as indicated in the previous message.", cacheId);
+        }
 
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
@@ -18,7 +23,8 @@ namespace WixToolset.Core.Burn
 
         public enum Ids
         {
-            // ReplaceThisWithTheFirstError = 8000,
+            DuplicateCacheIds = 8000,
+            DuplicateCacheIds2 = 8001,
         }
     }
 }

--- a/src/test/WixToolsetTest.CoreIntegration/BindVariablesFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BindVariablesFixture.cs
@@ -10,7 +10,7 @@ namespace WixToolsetTest.CoreIntegration
 
     public class BindVariablesFixture
     {
-        [Fact(Skip = "Test demonstrates failure")]
+        [Fact]
         public void CanBuildBundleWithPackageBindVariables()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -280,7 +280,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "https://github.com/wixtoolset/issues/issues/4628")]
+        [Fact]
         public void CantBuildWithDuplicateCacheIds()
         {
             var folder = TestData.Get(@"TestData");
@@ -302,7 +302,7 @@ namespace WixToolsetTest.CoreIntegration
                     "-o", exePath,
                 });
 
-                Assert.InRange(result.ExitCode, 2, Int32.MaxValue);
+                Assert.Equal(8001, result.ExitCode);
             }
         }
 

--- a/src/test/WixToolsetTest.CoreIntegration/PayloadFixture.cs
+++ b/src/test/WixToolsetTest.CoreIntegration/PayloadFixture.cs
@@ -143,7 +143,7 @@ namespace WixToolsetTest.CoreIntegration
             }
         }
 
-        [Fact(Skip = "Test demonstrates failure")]
+        [Fact]
         public void ReplacesDownloadUrlPlaceholders()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
+++ b/src/test/WixToolsetTest.CoreIntegration/TestData/BadInput/DuplicateCacheIds.wxs
@@ -2,8 +2,11 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <PackageGroup Id="BundlePackages">
-            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" CacheId="Manual" />
-            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" CacheId="Manual" />
+            <ExePackage Id="Manual1" SourceFile="burn.exe" Name="manual1\burn.exe" DetectCondition="test" CacheId="!(wix.WixVariable1)" />
+            <ExePackage Id="Manual2" SourceFile="burn.exe" Name="manual2\burn.exe" DetectCondition="test" CacheId="!(wix.WixVariable2)" />
         </PackageGroup>
+
+        <WixVariable Id="WixVariable1" Value="CollidingCacheId" />
+        <WixVariable Id="WixVariable2" Value="CollidingCacheId" />
     </Fragment>
 </Wix>


### PR DESCRIPTION
Resolve container and payload DownloadUrls
Set well-known deferred properties to String.Empty when not present
Detect duplicate CacheIds

Fixes wixtoolset/issues#4628
Fixes wixtoolset/issues#6405
Fixes wixtoolset/issues#6431
Resolves #272 